### PR TITLE
Send broadcast to all network interfaces

### DIFF
--- a/Hazel.UnitTests/BroadcastTests.cs
+++ b/Hazel.UnitTests/BroadcastTests.cs
@@ -1,8 +1,6 @@
 ﻿using Hazel.Udp;
-using Hazel.UPnP;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using System.Net.NetworkInformation;
 using System.Threading;
 
 namespace Hazel.UnitTests

--- a/Hazel.UnitTests/BroadcastTests.cs
+++ b/Hazel.UnitTests/BroadcastTests.cs
@@ -1,8 +1,8 @@
 ﻿using Hazel.Udp;
+using Hazel.UPnP;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using System.Linq;
-using System.Net;
+using System.Net.NetworkInformation;
 using System.Threading;
 
 namespace Hazel.UnitTests
@@ -32,7 +32,7 @@ namespace Hazel.UnitTests
                     Assert.AreEqual(TestData, p.Data);
                 }
 
-                Assert.AreEqual(1, pkt.Length);
+                Assert.IsTrue(pkt.Length >= 1);
             }
         }
     }

--- a/Hazel/UPnP/NetUtility.cs
+++ b/Hazel/UPnP/NetUtility.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Net.NetworkInformation;
 using System.Net.Sockets;
@@ -7,61 +9,77 @@ namespace Hazel.UPnP
 {
     internal class NetUtility
     {
-        private static NetworkInterface GetNetworkInterface()
+        private static IEnumerable<NetworkInterface> GetValidNetworkInterfaces()
         {
-            var computerProperties = IPGlobalProperties.GetIPGlobalProperties();
-            if (computerProperties == null)
-                return null;
-
             var nics = NetworkInterface.GetAllNetworkInterfaces();
             if (nics == null || nics.Length < 1)
-                return null;
+                yield break;
 
             NetworkInterface best = null;
             foreach (NetworkInterface adapter in nics)
             {
                 if (adapter.NetworkInterfaceType == NetworkInterfaceType.Loopback || adapter.NetworkInterfaceType == NetworkInterfaceType.Unknown)
                     continue;
-                if (!adapter.Supports(NetworkInterfaceComponent.IPv4))
+                if (!adapter.Supports(NetworkInterfaceComponent.IPv4) && !adapter.Supports(NetworkInterfaceComponent.IPv6))
                     continue;
                 if (best == null)
                     best = adapter;
                 if (adapter.OperationalStatus != OperationalStatus.Up)
                     continue;
 
-                // make sure this adapter has any ipv4 addresses
+                // make sure this adapter has any ip addresses
                 IPInterfaceProperties properties = adapter.GetIPProperties();
+                foreach (UnicastIPAddressInformation unicastAddress in properties.UnicastAddresses)
+                {
+                    if (unicastAddress != null && unicastAddress.Address != null)
+                    {
+                        // Yes it does, return this network interface.
+                        yield return adapter;
+                        best = null;
+                    }
+                }
+            }
+
+            if (best != null)
+                yield return best;
+        }
+
+        /// <summary>
+        /// Gets the addresses from all active network interfaces, but at most one per interface.
+        /// </summary>
+        /// <param name="addressFamily">The <see cref="AddressFamily"/> of the addresses to return</param>
+        /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnicastIPAddressInformation"/>.</returns>
+        public static IEnumerable<UnicastIPAddressInformation> GetAddressesFromNetworkInterfaces(AddressFamily addressFamily)
+        {
+            foreach (NetworkInterface adapter in GetValidNetworkInterfaces())
+            {
+                IPInterfaceProperties properties = adapter.GetIPProperties();
+                foreach (UnicastIPAddressInformation unicastAddress in properties.UnicastAddresses)
+                {
+                    if (unicastAddress != null && unicastAddress.Address != null && unicastAddress.Address.AddressFamily == addressFamily)
+                    {
+                        yield return unicastAddress;
+                        break;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets my local IPv4 address (not necessarily external) and subnet mask
+        /// </summary>
+        public static IPAddress GetMyAddress(out IPAddress mask)
+        {
+            IPInterfaceProperties properties = GetValidNetworkInterfaces().FirstOrDefault()?.GetIPProperties();
+            if (properties != null)
+            {
                 foreach (UnicastIPAddressInformation unicastAddress in properties.UnicastAddresses)
                 {
                     if (unicastAddress != null && unicastAddress.Address != null && unicastAddress.Address.AddressFamily == AddressFamily.InterNetwork)
                     {
-                        // Yes it does, return this network interface.
-                        return adapter;
+                        mask = unicastAddress.IPv4Mask;
+                        return unicastAddress.Address;
                     }
-                }
-            }
-            return best;
-        }
-
-        /// <summary>
-		/// Gets my local IPv4 address (not necessarily external) and subnet mask
-		/// </summary>
-		public static IPAddress GetMyAddress(out IPAddress mask)
-        {
-            var ni = GetNetworkInterface();
-            if (ni == null)
-            {
-                mask = null;
-                return null;
-            }
-
-            IPInterfaceProperties properties = ni.GetIPProperties();
-            foreach (UnicastIPAddressInformation unicastAddress in properties.UnicastAddresses)
-            {
-                if (unicastAddress != null && unicastAddress.Address != null && unicastAddress.Address.AddressFamily == AddressFamily.InterNetwork)
-                {
-                    mask = unicastAddress.IPv4Mask;
-                    return unicastAddress.Address;
                 }
             }
 
@@ -69,33 +87,54 @@ namespace Hazel.UPnP
             return null;
         }
 
+        /// <summary>
+        /// Gets the broadcast address for the first network interface or, if not able to,
+        /// the limited broadcast address.
+        /// </summary>
+        /// <returns>An <see cref="IPAddress"/> for broadcasting.</returns>
         public static IPAddress GetBroadcastAddress()
         {
-            var ni = GetNetworkInterface();
-            if (ni == null)
-                return null;
-
-            var properties = ni.GetIPProperties();
-            foreach (UnicastIPAddressInformation unicastAddress in properties.UnicastAddresses)
+            var properties = GetValidNetworkInterfaces().FirstOrDefault()?.GetIPProperties();
+            if (properties != null)
             {
-                if (unicastAddress != null && unicastAddress.Address != null && unicastAddress.Address.AddressFamily == AddressFamily.InterNetwork)
+                foreach (UnicastIPAddressInformation unicastAddress in properties.UnicastAddresses)
                 {
-                    var mask = unicastAddress.IPv4Mask;
-                    byte[] ipAdressBytes = unicastAddress.Address.GetAddressBytes();
-                    byte[] subnetMaskBytes = mask.GetAddressBytes();
-
-                    if (ipAdressBytes.Length != subnetMaskBytes.Length)
-                        throw new ArgumentException("Lengths of IP address and subnet mask do not match.");
-
-                    byte[] broadcastAddress = new byte[ipAdressBytes.Length];
-                    for (int i = 0; i < broadcastAddress.Length; i++)
+                    var ipAddress = GetBroadcastAddress(unicastAddress);
+                    if (ipAddress != null)
                     {
-                        broadcastAddress[i] = (byte)(ipAdressBytes[i] | (subnetMaskBytes[i] ^ 255));
+                        return ipAddress;
                     }
-                    return new IPAddress(broadcastAddress);
                 }
             }
+            
             return IPAddress.Broadcast;
+        }
+
+        /// <summary>
+        /// Gets the broadcast address for the given <paramref name="unicastAddress"/>.
+        /// </summary>
+        /// <param name="unicastAddress">A <see cref="UnicastIPAddressInformation"/></param>
+        /// <returns>An <see cref="IPAddress"/> for broadcasting.</returns>
+        public static IPAddress GetBroadcastAddress(UnicastIPAddressInformation unicastAddress)
+        {
+            if (unicastAddress != null && unicastAddress.Address != null && unicastAddress.Address.AddressFamily == AddressFamily.InterNetwork)
+            {
+                var mask = unicastAddress.IPv4Mask;
+                byte[] ipAdressBytes = unicastAddress.Address.GetAddressBytes();
+                byte[] subnetMaskBytes = mask.GetAddressBytes();
+
+                if (ipAdressBytes.Length != subnetMaskBytes.Length)
+                    throw new ArgumentException("Lengths of IP address and subnet mask do not match.");
+
+                byte[] broadcastAddress = new byte[ipAdressBytes.Length];
+                for (int i = 0; i < broadcastAddress.Length; i++)
+                {
+                    broadcastAddress[i] = (byte)(ipAdressBytes[i] | (subnetMaskBytes[i] ^ 255));
+                }
+                return new IPAddress(broadcastAddress);
+            }
+
+            return null;
         }
     }
 }

--- a/Hazel/UPnP/NetUtility.cs
+++ b/Hazel/UPnP/NetUtility.cs
@@ -95,12 +95,12 @@ namespace Hazel.UPnP
         /// <returns>An <see cref="IPAddress"/> for broadcasting.</returns>
         public static IPAddress GetBroadcastAddress()
         {
-            var properties = GetValidNetworkInterfaces().FirstOrDefault()?.GetIPProperties();
+            IPInterfaceProperties properties = GetValidNetworkInterfaces().FirstOrDefault()?.GetIPProperties();
             if (properties != null)
             {
                 foreach (UnicastIPAddressInformation unicastAddress in properties.UnicastAddresses)
                 {
-                    var ipAddress = GetBroadcastAddress(unicastAddress);
+                    IPAddress ipAddress = GetBroadcastAddress(unicastAddress);
                     if (ipAddress != null)
                     {
                         return ipAddress;
@@ -115,7 +115,8 @@ namespace Hazel.UPnP
         /// Gets the broadcast address for the given <paramref name="unicastAddress"/>.
         /// </summary>
         /// <param name="unicastAddress">A <see cref="UnicastIPAddressInformation"/></param>
-        /// <returns>An <see cref="IPAddress"/> for broadcasting.</returns>
+        /// <returns>An <see cref="IPAddress"/> for broadcasting, null if the <paramref name="unicastAddress"/>
+        /// is not an IPv4 address.</returns>
         public static IPAddress GetBroadcastAddress(UnicastIPAddressInformation unicastAddress)
         {
             if (unicastAddress != null && unicastAddress.Address != null && unicastAddress.Address.AddressFamily == AddressFamily.InterNetwork)

--- a/Hazel/UPnP/NetUtility.cs
+++ b/Hazel/UPnP/NetUtility.cs
@@ -36,6 +36,7 @@ namespace Hazel.UPnP
                         // Yes it does, return this network interface.
                         yield return adapter;
                         best = null;
+                        break;
                     }
                 }
             }

--- a/Hazel/Udp/UdpBroadcaster.cs
+++ b/Hazel/Udp/UdpBroadcaster.cs
@@ -21,17 +21,16 @@ namespace Hazel.Udp
 
             foreach (var addressInformation in NetUtility.GetAddressesFromNetworkInterfaces(AddressFamily.InterNetwork))
             {
-                var socket = CreateSocket(new IPEndPoint(addressInformation.Address, 0));
-                var broadcast = NetUtility.GetBroadcastAddress(addressInformation);
+                Socket socket = CreateSocket(new IPEndPoint(addressInformation.Address, 0));
+                IPAddress broadcast = NetUtility.GetBroadcastAddress(addressInformation);
 
                 this.socketBroadcasts.Add(new SocketBroadcast(socket, new IPEndPoint(broadcast, port)));
             }
             if (socketBroadcasts.Count == 0)
             {
-                var socket = CreateSocket(new IPEndPoint(IPAddress.Any, 0));
-                var broadcast = NetUtility.GetBroadcastAddress();
+                Socket socket = CreateSocket(new IPEndPoint(IPAddress.Any, 0));
 
-                this.socketBroadcasts.Add(new SocketBroadcast(socket, new IPEndPoint(broadcast, port)));
+                this.socketBroadcasts.Add(new SocketBroadcast(socket, new IPEndPoint(IPAddress.Broadcast, port)));
             }
         }
 
@@ -68,7 +67,7 @@ namespace Hazel.Udp
             {
                 try
                 {
-                    var socket = socketBroadcast.Socket;
+                    Socket socket = socketBroadcast.Socket;
                     socket.BeginSendTo(data, 0, data.Length, SocketFlags.None, socketBroadcast.Broadcast, this.FinishSendTo, socket);
                 }
                 catch (Exception e)
@@ -96,7 +95,7 @@ namespace Hazel.Udp
         {
             foreach (SocketBroadcast socketBroadcast in this.socketBroadcasts)
             {
-                var socket = socketBroadcast.Socket;
+                Socket socket = socketBroadcast.Socket;
                 if (socket != null)
                 {
                     try { socket.Shutdown(SocketShutdown.Both); } catch { }


### PR DESCRIPTION
I noticed, when fiddling around with Among Us, that I wasn't able to host a local game on my computer. In Wireshark it turned out, that in fact no broadcast was sent out.
Instead they were sent on the virtual adapter and only there. After research, I found out, that you must bind the socket to every network interface, if you want to send it out on more than one.

I decided to fix it myself. (I was already in the Hazel code for some time, due to some refactoring around IPv6 and also enabling multicast support, so I stashed that work)
To save on allocations and not introduce new dependencies I created a new struct inside of UdpBroadcaster, which holds the Socket and Endpoint (instead of using System.Tuple (which is a reference type), System.ValueType (which is a nuget package)).

I verified that this is indeed working and will send a broadcast on every network interface and not just the first that it finds in the routing table.