### PR TITLE
Fix resent handshake failure

### DIFF
--- a/Hazel.UnitTests/Hazel.UnitTests.csproj
+++ b/Hazel.UnitTests/Hazel.UnitTests.csproj
@@ -66,6 +66,7 @@
     <Compile Include="Dtls\ConnectionTests.cs" />
     <Compile Include="Dtls\X25519EcdheRsaSha256Tests.cs" />
     <Compile Include="MessageReaderTests.cs" />
+    <Compile Include="SocketCapture.cs" />
     <Compile Include="StatisticsTests.cs" />
     <Compile Include="TestHelper.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Hazel.UnitTests/SocketCapture.cs
+++ b/Hazel.UnitTests/SocketCapture.cs
@@ -1,0 +1,169 @@
+using System;
+using System.Collections.Concurrent;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+
+namespace Hazel.UnitTests
+{
+    /// <summary>
+    /// Acts as an intermediate between to sockets.
+    /// 
+    /// Use SendToLocalSemaphore and SendToRemoteSemaphore for
+    /// explicit control of packet flow.
+    /// </summary>
+    public class SocketCapture : IDisposable
+    {
+        private IPEndPoint localEndPoint;
+        private readonly IPEndPoint remoteEndPoint;
+
+        private Socket captureSocket;
+
+        private Thread receiveThread;
+        private Thread forLocalThread;
+        private Thread forRemoteThread;
+
+        private readonly BlockingCollection<ByteSpan> forLocal = new BlockingCollection<ByteSpan>();
+        private readonly BlockingCollection<ByteSpan> forRemote = new BlockingCollection<ByteSpan>();
+
+        public Semaphore SendToLocalSemaphore = null;
+        public Semaphore SendToRemoteSemaphore = null;
+
+        private CancellationTokenSource cancellationSource = new CancellationTokenSource();
+        private readonly CancellationToken cancellationToken;
+
+        public SocketCapture(IPEndPoint captureEndpoint, IPEndPoint remoteEndPoint)
+        {
+            this.cancellationToken = this.cancellationSource.Token;
+
+            this.remoteEndPoint = remoteEndPoint;
+
+            this.captureSocket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+            this.captureSocket.Bind(captureEndpoint);
+
+            this.receiveThread = new Thread(this.ReceiveLoop);
+            this.receiveThread.Start();
+
+            this.forLocalThread = new Thread(this.SendToLocalLoop);
+            this.forLocalThread.Start();
+
+            this.forRemoteThread = new Thread(this.SendToRemoteLoop);
+            this.forRemoteThread.Start();
+        }
+
+        public void Dispose()
+        {
+            if (this.cancellationSource != null)
+            {
+                this.cancellationSource.Cancel();
+                this.cancellationSource.Dispose();
+                this.cancellationSource = null;
+            }
+
+            if (this.captureSocket != null)
+            {
+                this.captureSocket.Close();
+                this.captureSocket.Dispose();
+                this.captureSocket = null;
+            }
+
+            if (this.receiveThread != null)
+            {
+                this.receiveThread.Join();
+                this.receiveThread = null;
+            }
+
+            if (this.forLocalThread != null)
+            {
+                this.forLocalThread.Join();
+                this.forLocalThread = null;
+            }
+
+            if (this.forRemoteThread != null)
+            {
+                this.forRemoteThread.Join();
+                this.forRemoteThread = null;
+            }
+
+            GC.SuppressFinalize(this);
+        }
+
+        private void ReceiveLoop()
+        {
+            try
+            {
+                IPEndPoint fromEndPoint = new IPEndPoint(IPAddress.Any, 0);
+
+                byte[] buffer = new byte[2000];
+                for (; ; )
+                {
+                    EndPoint endPoint = fromEndPoint;
+                    int read = this.captureSocket.ReceiveFrom(buffer, ref endPoint);
+                    if (read > 0)
+                    {
+                        // from the remote endpoint?
+                        if (IPEndPoint.Equals(endPoint, remoteEndPoint))
+                        {
+                            this.forLocal.Add(new ByteSpan(buffer, 0, read));
+                        }
+                        else
+                        {
+                            this.localEndPoint = (IPEndPoint)endPoint;
+                            this.forRemote.Add(new ByteSpan(buffer, 0, read));
+                        }
+                    }
+                }
+            }
+            catch (SocketException)
+            {
+            }
+            finally
+            {
+                this.forLocal.CompleteAdding();
+                this.forRemote.CompleteAdding();
+            }
+        }
+
+        private void SendToRemoteLoop()
+        {
+            foreach (ByteSpan packet in this.forRemote.GetConsumingEnumerable())
+            {
+                if (this.cancellationToken.IsCancellationRequested)
+                {
+                    break;
+                }
+
+                if (this.SendToRemoteSemaphore != null)
+                {
+                    if (!this.SendToRemoteSemaphore.WaitOne(100))
+                    {
+                        continue;
+                    }
+                }
+
+                this.captureSocket.SendTo(packet.GetUnderlyingArray(), packet.Offset, packet.Length, SocketFlags.None, this.remoteEndPoint);
+            }
+        }
+
+        private void SendToLocalLoop()
+        {
+            foreach (ByteSpan packet in this.forLocal.GetConsumingEnumerable())
+            {
+                if (this.cancellationToken.IsCancellationRequested)
+                {
+                    break;
+                }
+
+                if (this.SendToLocalSemaphore != null)
+                {
+                    if (!this.SendToLocalSemaphore.WaitOne(100))
+                    {
+                        continue;
+                    }
+                }
+
+                this.captureSocket.SendTo(packet.GetUnderlyingArray(), packet.Offset, packet.Length, SocketFlags.None, this.localEndPoint);
+            }
+        }
+    }
+}

--- a/Hazel/Dtls/DtlsUnityConnection.cs
+++ b/Hazel/Dtls/DtlsUnityConnection.cs
@@ -199,6 +199,7 @@ namespace Hazel.Dtls
             lock (this.syncRoot)
             {
                 this.ResetConnectionState();
+                this.nextEpoch.ClientRandom.FillWithRandom(this.random);
                 this.SendClientHello();
             }
 
@@ -577,6 +578,7 @@ namespace Hazel.Dtls
                         helloVerifyRequest.Cookie.CopyTo(this.nextEpoch.Cookie);
 
                         // Restart the handshake
+                        this.nextEpoch.ClientRandom.FillWithRandom(this.random);
                         this.SendClientHello();
                         break;
 
@@ -882,7 +884,6 @@ namespace Hazel.Dtls
         {
             // Reset our verification stream
             this.nextEpoch.VerificationStream.SetLength(0);
-            this.nextEpoch.ClientRandom.FillWithRandom(this.random);
 
             // Describe our ClientHello flight
             ClientHello clientHello = new ClientHello();


### PR DESCRIPTION
This addresses the client-side issue where resending a timed-out ClientHello message re-generates the ClientRandom value and thereby desynchronizes the session with the server. This manifests itself as the server refusing the connection due to a mismatched hash in the Finished handshake message