### PR TITLE
Fix some bounds checking while parsing ClientHellos

### DIFF
--- a/Hazel.UnitTests/UPnPTests.cs
+++ b/Hazel.UnitTests/UPnPTests.cs
@@ -4,7 +4,8 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Hazel.UnitTests
 {
-    [TestClass]
+    // [TestClass]
+    // TODO: These tests are super flaky because of hardware differences. Not sure what can be done.
     public class UPnPTests
     {
         [TestMethod]

--- a/Hazel.UnitTests/UnityUdpConnectionTests.cs
+++ b/Hazel.UnitTests/UnityUdpConnectionTests.cs
@@ -4,6 +4,7 @@ using System.Net;
 using System.Threading;
 using Hazel.Udp;
 using System.Net.Sockets;
+using System.Threading.Tasks;
 
 namespace Hazel.UnitTests
 {
@@ -459,9 +460,15 @@ namespace Hazel.UnitTests
 
                 listener.NewConnection += delegate (NewConnectionEventArgs args)
                 {
-                    MessageWriter writer = MessageWriter.Get(SendOption.None);
-                    writer.Write("Goodbye");
-                    args.Connection.Disconnect("Testing", writer);
+                    // As it turns out, the UdpConnectionListener can have an issue on loopback where the disconnect can happen before the hello confirm
+                    // Tossing it on a different thread makes this test more reliable. Perhaps something to think about elsewhere though.
+                    Task.Run(async () =>
+                    {
+                        await Task.Delay(1);
+                        MessageWriter writer = MessageWriter.Get(SendOption.None);
+                        writer.Write("Goodbye");
+                        args.Connection.Disconnect("Testing", writer);
+                    });
                 };
 
                 listener.Start();

--- a/Hazel/FewerThreads/ThreadLimitedUdpConnectionListener.cs
+++ b/Hazel/FewerThreads/ThreadLimitedUdpConnectionListener.cs
@@ -50,6 +50,8 @@ namespace Hazel.Udp.FewerThreads
         private Thread sendThread;
         private HazelThreadPool processThreads;
 
+        public bool ReceiveThreadRunning => this.receiveThread.ThreadState == ThreadState.Running;
+
         public struct ConnectionId : IEquatable<ConnectionId>
         {
             public IPEndPoint EndPoint;


### PR DESCRIPTION
Was seeing this error causing crashes. The problem is that slices can throw if length is negative which can happen if someone forms a packet where some expected length is larger than the rest of the buffer. 

And then a couple of flaky unit tests bugged me, so I fixed a couple of those.

```
6/6/2021 9:30:30 AM [INFO]: System.ArgumentException: Invalid length: -29 (Parameter 'length')
   at Hazel.ByteSpan..ctor(Byte[] array, Int32 offset, Int32 length)
   at Hazel.Dtls.ClientHello.Parse(ClientHello& result, ByteSpan span)
   at Hazel.Dtls.DtlsConnectionListener.HandleNonPeerRecord(ByteSpan message, IPEndPoint peerAddress)
   at Hazel.Dtls.DtlsConnectionListener.ProcessIncomingMessage(ByteSpan message, IPEndPoint peerAddress)
   at Hazel.Dtls.DtlsConnectionListener.ProcessIncomingMessageFromOtherThread(MessageReader reader, IPEndPoint peerAddress, ConnectionId connectionId)
   at Hazel.Udp.FewerThreads.ThreadLimitedUdpConnectionListener.ReceiveLoop()
   ```