### PR TITLE
Added InsertMessage function to MessageReader

### DIFF
--- a/Hazel.UnitTests/MessageReaderTests.cs
+++ b/Hazel.UnitTests/MessageReaderTests.cs
@@ -407,6 +407,80 @@ namespace Hazel.UnitTests
         }
 
         [TestMethod]
+        public void InsertMessageMultipleInsertsWithoutReset()
+        {
+            const byte Test0 = 11;
+            const byte Test3 = 33;
+            const byte Test4 = 44;
+            const byte Test5 = 55;
+            const byte Test6 = 66;
+            const byte TestInsert = 77;
+            const byte TestInsert2 = 88;
+
+            var msg = new MessageWriter(2048);
+            msg.StartMessage(0);
+            msg.Write(Test0);
+            msg.EndMessage();
+
+            msg.StartMessage(12);
+            msg.StartMessage(23);
+
+            msg.StartMessage(34);
+            msg.Write(Test3);
+            msg.EndMessage();
+
+            msg.StartMessage(45);
+            msg.Write(Test4);
+            msg.EndMessage();
+
+            msg.EndMessage();
+
+            msg.StartMessage(56);
+            msg.Write(Test5);
+            msg.EndMessage();
+
+            msg.EndMessage();
+
+            msg.StartMessage(67);
+            msg.Write(Test6);
+            msg.EndMessage();
+
+            MessageReader reader = MessageReader.Get(msg.Buffer);
+
+            MessageWriter writer = MessageWriter.Get(SendOption.Reliable);
+            writer.StartMessage(5);
+            writer.Write(TestInsert);
+            writer.EndMessage();
+
+            MessageWriter writer2 = MessageWriter.Get(SendOption.Reliable);
+            writer2.StartMessage(6);
+            writer2.Write(TestInsert2);
+            writer2.EndMessage();
+
+            reader.ReadMessage();
+            var one = reader.ReadMessage();
+            var two = one.ReadMessage();
+            var three = two.ReadMessage();
+
+            two.InsertMessage(three, writer);
+
+            // three becomes invalid
+            Assert.AreNotEqual(Test3, three.ReadByte());
+
+            // Continuing to read works
+            var four = two.ReadMessage();
+            Assert.AreEqual(Test4, four.ReadByte());
+
+            var five = one.ReadMessage();
+            Assert.AreEqual(Test5, five.ReadByte());
+
+            reader.InsertMessage(one, writer2);
+
+            var six = reader.ReadMessage();
+            Assert.AreEqual(Test6, six.ReadByte());
+        }
+
+        [TestMethod]
         public void CopySubMessage()
         {
             const byte Test1 = 12;

--- a/Hazel.UnitTests/MessageReaderTests.cs
+++ b/Hazel.UnitTests/MessageReaderTests.cs
@@ -146,6 +146,267 @@ namespace Hazel.UnitTests
         }
 
         [TestMethod]
+        public void InsertMessageWorks()
+        {
+            const byte Test0 = 11;
+            const byte Test3 = 33;
+            const byte Test4 = 44;
+            const byte Test5 = 55;
+            const byte TestInsert = 66;
+
+            var msg = new MessageWriter(2048);
+            msg.StartMessage(0);
+            msg.Write(Test0);
+            msg.EndMessage();
+
+            msg.StartMessage(12);
+            msg.StartMessage(23);
+
+            msg.StartMessage(34);
+            msg.Write(Test3);
+            msg.EndMessage();
+
+            msg.StartMessage(45);
+            msg.Write(Test4);
+            msg.EndMessage();
+
+            msg.EndMessage();
+            msg.EndMessage();
+
+            msg.StartMessage(56);
+            msg.Write(Test5);
+            msg.EndMessage();
+
+            MessageReader reader = MessageReader.Get(msg.Buffer);
+
+            MessageWriter writer = MessageWriter.Get(SendOption.Reliable);
+            writer.StartMessage(5);
+            writer.Write(TestInsert);
+            writer.EndMessage();
+
+            reader.ReadMessage();
+            var one = reader.ReadMessage();
+            var two = one.ReadMessage();
+            var three = two.ReadMessage();
+
+            two.InsertMessage(three, writer);
+
+            //set the position back to zero to read back the updated message
+            reader.Position = 0;
+
+            var zero = reader.ReadMessage();
+            Assert.AreEqual(Test0, zero.ReadByte());
+            one = reader.ReadMessage();
+            two = one.ReadMessage();
+            var insert = two.ReadMessage();
+            Assert.AreEqual(TestInsert, insert.ReadByte());
+            three = two.ReadMessage();
+            Assert.AreEqual(Test3, three.ReadByte());
+            var four = two.ReadMessage();
+            Assert.AreEqual(Test4, four.ReadByte());
+
+            var five = reader.ReadMessage();
+            Assert.AreEqual(Test5, five.ReadByte());
+        }
+
+        [TestMethod]
+        public void InsertMessageWorksWithSendOptionNone()
+        {
+            const byte Test0 = 11;
+            const byte Test3 = 33;
+            const byte Test4 = 44;
+            const byte Test5 = 55;
+            const byte TestInsert = 66;
+
+            var msg = new MessageWriter(2048);
+            msg.StartMessage(0);
+            msg.Write(Test0);
+            msg.EndMessage();
+
+            msg.StartMessage(12);
+            msg.StartMessage(23);
+
+            msg.StartMessage(34);
+            msg.Write(Test3);
+            msg.EndMessage();
+
+            msg.StartMessage(45);
+            msg.Write(Test4);
+            msg.EndMessage();
+
+            msg.EndMessage();
+            msg.EndMessage();
+
+            msg.StartMessage(56);
+            msg.Write(Test5);
+            msg.EndMessage();
+
+            MessageReader reader = MessageReader.Get(msg.Buffer);
+
+            MessageWriter writer = MessageWriter.Get(SendOption.None);
+            writer.StartMessage(5);
+            writer.Write(TestInsert);
+            writer.EndMessage();
+
+            reader.ReadMessage();
+            var one = reader.ReadMessage();
+            var two = one.ReadMessage();
+            var three = two.ReadMessage();
+
+            two.InsertMessage(three, writer);
+
+            //set the position back to zero to read back the updated message
+            reader.Position = 0;
+
+            var zero = reader.ReadMessage();
+            Assert.AreEqual(Test0, zero.ReadByte());
+            one = reader.ReadMessage();
+            two = one.ReadMessage();
+            var insert = two.ReadMessage();
+            Assert.AreEqual(TestInsert, insert.ReadByte());
+            three = two.ReadMessage();
+            Assert.AreEqual(Test3, three.ReadByte());
+            var four = two.ReadMessage();
+            Assert.AreEqual(Test4, four.ReadByte());
+
+            var five = reader.ReadMessage();
+            Assert.AreEqual(Test5, five.ReadByte());
+
+        }
+
+        [TestMethod]
+        public void InsertMessageWithoutStartMessageInWriter()
+        {
+            const byte Test0 = 11;
+            const byte Test3 = 33;
+            const byte Test4 = 44;
+            const byte Test5 = 55;
+            const byte TestInsert = 66;
+
+            var msg = new MessageWriter(2048);
+            msg.StartMessage(0);
+            msg.Write(Test0);
+            msg.EndMessage();
+
+            msg.StartMessage(12);
+            msg.StartMessage(23);
+
+            msg.StartMessage(34);
+            msg.Write(Test3);
+            msg.EndMessage();
+
+            msg.StartMessage(45);
+            msg.Write(Test4);
+            msg.EndMessage();
+
+            msg.EndMessage();
+            msg.EndMessage();
+
+            msg.StartMessage(56);
+            msg.Write(Test5);
+            msg.EndMessage();
+
+            MessageReader reader = MessageReader.Get(msg.Buffer);
+
+            MessageWriter writer = MessageWriter.Get(SendOption.Reliable);
+            writer.Write(TestInsert);
+
+            reader.ReadMessage();
+            var one = reader.ReadMessage();
+            var two = one.ReadMessage();
+            var three = two.ReadMessage();
+
+            two.InsertMessage(three, writer);
+
+            //set the position back to zero to read back the updated message
+            reader.Position = 0;
+
+            var zero = reader.ReadMessage();
+            Assert.AreEqual(Test0, zero.ReadByte());
+            one = reader.ReadMessage();
+            two = one.ReadMessage();
+            Assert.AreEqual(TestInsert, two.ReadByte());
+            three = two.ReadMessage();
+            Assert.AreEqual(Test3, three.ReadByte());
+            var four = two.ReadMessage();
+            Assert.AreEqual(Test4, four.ReadByte());
+
+            var five = reader.ReadMessage();
+            Assert.AreEqual(Test5, five.ReadByte());
+        }
+
+        [TestMethod]
+        public void InsertMessageWithMultipleMessagesInWriter()
+        {
+            const byte Test0 = 11;
+            const byte Test3 = 33;
+            const byte Test4 = 44;
+            const byte Test5 = 55;
+            const byte TestInsert = 66;
+            const byte TestInsert2 = 77;
+
+            var msg = new MessageWriter(2048);
+            msg.StartMessage(0);
+            msg.Write(Test0);
+            msg.EndMessage();
+
+            msg.StartMessage(12);
+            msg.StartMessage(23);
+
+            msg.StartMessage(34);
+            msg.Write(Test3);
+            msg.EndMessage();
+
+            msg.StartMessage(45);
+            msg.Write(Test4);
+            msg.EndMessage();
+
+            msg.EndMessage();
+            msg.EndMessage();
+
+            msg.StartMessage(56);
+            msg.Write(Test5);
+            msg.EndMessage();
+
+            MessageReader reader = MessageReader.Get(msg.Buffer);
+
+            MessageWriter writer = MessageWriter.Get(SendOption.Reliable);
+            writer.StartMessage(5);
+            writer.Write(TestInsert);
+            writer.EndMessage();
+
+            writer.StartMessage(6);
+            writer.Write(TestInsert2);
+            writer.EndMessage();
+
+            reader.ReadMessage();
+            var one = reader.ReadMessage();
+            var two = one.ReadMessage();
+            var three = two.ReadMessage();
+
+            two.InsertMessage(three, writer);
+
+            //set the position back to zero to read back the updated message
+            reader.Position = 0;
+
+            var zero = reader.ReadMessage();
+            Assert.AreEqual(Test0, zero.ReadByte());
+            one = reader.ReadMessage();
+            two = one.ReadMessage();
+            var insert = two.ReadMessage();
+            Assert.AreEqual(TestInsert, insert.ReadByte());
+            var insert2 = two.ReadMessage();
+            Assert.AreEqual(TestInsert2, insert2.ReadByte());
+            three = two.ReadMessage();
+            Assert.AreEqual(Test3, three.ReadByte());
+            var four = two.ReadMessage();
+            Assert.AreEqual(Test4, four.ReadByte());
+
+            var five = reader.ReadMessage();
+            Assert.AreEqual(Test5, five.ReadByte());
+        }
+
+        [TestMethod]
         public void CopySubMessage()
         {
             const byte Test1 = 12;

--- a/Hazel/MessageReader.cs
+++ b/Hazel/MessageReader.cs
@@ -199,17 +199,27 @@ namespace Hazel
                 var headerOffset = reader.Offset - 3;
                 var startOfMessage = reader.Offset;
                 var len = reader.Buffer.Length - startOfMessage;
+                int writerOffset = 3;
+                switch (writer.SendOption)
+                {
+                    case SendOption.Reliable:
+                        writerOffset = 3;
+                        break;
+                    case SendOption.None:
+                        writerOffset = 1;
+                        break;
+                }
                 
                 //store the original buffer in temp
-                Array.Copy(reader.Buffer, startOfMessage, temp.Buffer, 0, len);
+                Array.Copy(reader.Buffer, headerOffset, temp.Buffer, 0, len);
 
                 //put the contents of writer in at headerOffset
-                Array.Copy(writer.Buffer, 3, this.Buffer, headerOffset, writer.Length);
+                Array.Copy(writer.Buffer, writerOffset, this.Buffer, headerOffset, writer.Length-writerOffset);
 
                 //put the original buffer in after that
-                Array.Copy(temp.Buffer, 0, this.Buffer, headerOffset + writer.Length, len - writer.Length);
+                Array.Copy(temp.Buffer, 0, this.Buffer, headerOffset + (writer.Length-writerOffset), len - writer.Length);
 
-                this.AdjustLength(-1 * reader.Offset , -1 * (writer.Length - 3));
+                this.AdjustLength(-1 * reader.Offset , -1 * (writer.Length - writerOffset));
             }
             finally
             {

--- a/Hazel/MessageReader.cs
+++ b/Hazel/MessageReader.cs
@@ -191,6 +191,32 @@ namespace Hazel
             }
         }
 
+        public void InsertMessage(MessageReader reader, MessageWriter writer)
+        {
+            var temp = MessageReader.GetSized(reader.Buffer.Length);
+            try 
+            {
+                var headerOffset = reader.Offset - 3;
+                var startOfMessage = reader.Offset;
+                var len = reader.Buffer.Length - startOfMessage;
+                
+                //store the original buffer in temp
+                Array.Copy(reader.Buffer, startOfMessage, temp.Buffer, 0, len);
+
+                //put the contents of writer in at headerOffset
+                Array.Copy(writer.Buffer, 3, this.Buffer, headerOffset, writer.Length);
+
+                //put the original buffer in after that
+                Array.Copy(temp.Buffer, 0, this.Buffer, headerOffset + writer.Length, len - writer.Length);
+
+                this.AdjustLength(-1 * reader.Offset , -1 * (writer.Length - 3));
+            }
+            finally
+            {
+                temp.Recycle();
+            }
+        }
+
         private void AdjustLength(int offset, int amount)
         {
             if (this.readHead > offset)


### PR DESCRIPTION
This adds an `InsertMessage()` method to `MessageReader`. It should insert the contents of `writer` at the current location of `reader`, pushing back the rest of the message. This should leave the read head at the end of the inserted message (because doing otherwise would result in immediately reading the inserted message next time you try to read)