### PR TITLE
Fix a leak of PeerData entries

### DIFF
--- a/Hazel.UnitTests/StressTests.cs
+++ b/Hazel.UnitTests/StressTests.cs
@@ -1,8 +1,12 @@
 ﻿using System;
+using System.Linq;
 using System.Net;
+using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
+using Hazel.Dtls;
 using Hazel.Udp;
+using Hazel.Udp.FewerThreads;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Hazel.UnitTests
@@ -25,6 +29,45 @@ namespace Hazel.UnitTests
 
                 connection.Connect(new byte[5]);
             });
+        }
+
+        // This was a thing that happened to us a DDoS. Mildly instructional that we straight up ignore it.
+        public void SourceAmpAttack()
+        {
+            var localEp = new IPEndPoint(IPAddress.Any, 11710);
+            var serverEp = new IPEndPoint(IPAddress.Loopback, 11710);
+            using (ThreadLimitedUdpConnectionListener listener = new ThreadLimitedUdpConnectionListener(4, localEp, new ConsoleLogger(true)))
+            {
+                listener.Start();
+
+                Socket socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+                socket.DontFragment = false;
+
+                try
+                {
+                    const int SIO_UDP_CONNRESET = -1744830452;
+                    socket.IOControl(SIO_UDP_CONNRESET, new byte[1], null);
+                }
+                catch { } // Only necessary on Windows
+
+                string byteAsHex = "f23c 92d1 c277 001b 54c2 50c1 0800 4500 0035 7488 0000 3b11 2637 062f ac75 2d4f 0506 a7ea 5607 0021 5e07 ffff ffff 5453 6f75 7263 6520 456e 6769 6e65 2051 7565 7279 00";
+                byte[] bytes = StringToByteArray(byteAsHex.Replace(" ", ""));
+                socket.SendTo(bytes, serverEp);
+
+                while (socket.Poll(50000, SelectMode.SelectRead))
+                {
+                    byte[] buffer = new byte[1024];
+                    int len = socket.Receive(buffer);
+                    Console.WriteLine($"got {len} bytes: " + string.Join(" ", buffer.Select(b => b.ToString("X"))));
+                    Console.WriteLine($"got {len} bytes: " + string.Join(" ", buffer.Select(b => (char)b)));
+                }
+            }
+        }
+        public static byte[] StringToByteArray(string hex)
+        {
+            return Enumerable.Range(0, hex.Length / 2)
+                             .Select(x => Convert.ToByte(hex.Substring(x * 2, 2), 16))
+                             .ToArray();
         }
     }
 }

--- a/Hazel.UnitTests/ThreadLimitedUdpConnectionTests.cs
+++ b/Hazel.UnitTests/ThreadLimitedUdpConnectionTests.cs
@@ -62,7 +62,7 @@ namespace Hazel.UnitTests
         }
 
         [TestMethod]
-        public void ClientServerDisposeDisconnectsTest()
+        public void ClientDisposeDisconnectTest()
         {
             IPEndPoint ep = new IPEndPoint(IPAddress.Loopback, 4296);
 
@@ -484,7 +484,7 @@ namespace Hazel.UnitTests
 
                 connection.Connect();
 
-                mutex.WaitOne();
+                mutex.WaitOne(5000);
 
                 Assert.IsNotNull(received);
                 Assert.AreEqual("Goodbye", received);

--- a/Hazel/FewerThreads/ThreadLimitedUdpConnectionListener.cs
+++ b/Hazel/FewerThreads/ThreadLimitedUdpConnectionListener.cs
@@ -153,6 +153,7 @@ namespace Hazel.Udp.FewerThreads
             }
         }
 
+        // This is just for booting people after they've been connected a certain amount of time...
         public virtual void DisconnectOldConnections(TimeSpan maxAge, MessageWriter disconnectMessage)
         {
             var now = DateTime.UtcNow;
@@ -253,6 +254,7 @@ namespace Hazel.Udp.FewerThreads
                 }
             }
         }
+
         protected virtual void ProcessIncomingMessageFromOtherThread(MessageReader message, IPEndPoint remoteEndPoint, ConnectionId connectionId)
         {
             this.receiveQueue.Add(new ReceiveMessageInfo() { Message = message, Sender = remoteEndPoint, ConnectionId = connectionId });
@@ -365,7 +367,14 @@ namespace Hazel.Udp.FewerThreads
         /// <param name="endPoint">Connection key of the virtual connection.</param>
         internal bool RemoveConnectionTo(ConnectionId connectionId)
         {
-            return this.allConnections.TryRemove(connectionId, out var conn);
+            return this.allConnections.TryRemove(connectionId, out _);
+        }
+
+        /// <summary>
+        ///  This is after all messages could be sent. Clean up anything extra.
+        /// </summary>
+        internal virtual void RemovePeerRecord(ConnectionId connectionId)
+        {
         }
 
         protected virtual void Dispose(bool disposing)

--- a/Hazel/FewerThreads/ThreadLimitedUdpServerConnection.cs
+++ b/Hazel/FewerThreads/ThreadLimitedUdpServerConnection.cs
@@ -99,6 +99,7 @@ namespace Hazel.Udp.FewerThreads
                 SendDisconnect();
             }
 
+            Listener.RemovePeerRecord(this.ConnectionId);
             base.Dispose(disposing);
         }
     }


### PR DESCRIPTION
This happens when the peer suddenly goes quiet after connecting. 
Also tidy up some tests and reduce some logging noise.