### PR TITLE
Fix DTLS handshake failure from single SendClientKeyExchangeFlight drop

### DIFF
--- a/Hazel.UnitTests/Crypto/Sha256Tests.cs
+++ b/Hazel.UnitTests/Crypto/Sha256Tests.cs
@@ -21,7 +21,7 @@ namespace Hazel.UnitTests.Crypto
             using (Sha256Stream sha256 = new Sha256Stream())
             {
                 sha256.AddData(message);
-                sha256.CalculateHash(actualDigest);
+                sha256.CopyOrCalculateFinalHash(actualDigest);
             }
 
             CollectionAssert.AreEqual(expectedDigest, actualDigest);
@@ -41,7 +41,7 @@ namespace Hazel.UnitTests.Crypto
             using (Sha256Stream sha256 = new Sha256Stream())
             {
                 sha256.AddData(message);
-                sha256.CalculateHash(actualDigest);
+                sha256.CopyOrCalculateFinalHash(actualDigest);
             }
 
             CollectionAssert.AreEqual(expectedDigest, actualDigest);
@@ -61,7 +61,7 @@ namespace Hazel.UnitTests.Crypto
             using (Sha256Stream sha256 = new Sha256Stream())
             {
                 sha256.AddData(message);
-                sha256.CalculateHash(actualDigest);
+                sha256.CopyOrCalculateFinalHash(actualDigest);
             }
 
             CollectionAssert.AreEqual(expectedDigest, actualDigest);

--- a/Hazel.UnitTests/Dtls/TestDtlsHandshakeDropUnityConnection.cs
+++ b/Hazel.UnitTests/Dtls/TestDtlsHandshakeDropUnityConnection.cs
@@ -1,0 +1,27 @@
+﻿using Hazel.Dtls;
+using System.Net;
+
+namespace Hazel.UnitTests.Dtls
+{
+    internal class TestDtlsHandshakeDropUnityConnection : DtlsUnityConnection
+    {
+        public int DropSendClientKeyExchangeFlightCount = 0;
+
+        public TestDtlsHandshakeDropUnityConnection(ILogger logger, IPEndPoint remoteEndPoint, IPMode ipMode = IPMode.IPv4) : base(logger, remoteEndPoint, ipMode)
+        {
+
+        }
+
+        protected override bool DropClientKeyExchangeFlight()
+        {
+            if (DropSendClientKeyExchangeFlightCount > 0)
+            {
+                this.logger.WriteInfo($"Dropping SendClientKeyExchangeFlight");
+                --DropSendClientKeyExchangeFlightCount;
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/Hazel.UnitTests/Hazel.UnitTests.csproj
+++ b/Hazel.UnitTests/Hazel.UnitTests.csproj
@@ -65,6 +65,7 @@
     <Compile Include="Crypto\X25519Tests.cs" />
     <Compile Include="Dtls\AesGcmRecordProtectedTests.cs" />
     <Compile Include="Dtls\ConnectionTests.cs" />
+    <Compile Include="Dtls\TestDtlsHandshakeDropUnityConnection.cs" />
     <Compile Include="Dtls\X25519EcdheRsaSha256Tests.cs" />
     <Compile Include="MessageReaderTests.cs" />
     <Compile Include="SocketCapture.cs" />

--- a/Hazel/Crypto/Sha256Stream.cs
+++ b/Hazel/Crypto/Sha256Stream.cs
@@ -67,7 +67,7 @@ namespace Hazel.Crypto
         /// <param name="output">
         /// Target span to which the hash will be written
         /// </param>
-        public void CalculateHash(ByteSpan output)
+        public void CopyOrCalculateFinalHash(ByteSpan output)
         {
             if (output.Length != DigestSize)
             {

--- a/Hazel/Crypto/Sha256Stream.cs
+++ b/Hazel/Crypto/Sha256Stream.cs
@@ -14,6 +14,7 @@ namespace Hazel.Crypto
         public const int DigestSize = 32;
 
         private SHA256 hash = SHA256.Create();
+        private bool isHashFinished = false;
 
         struct EmptyArray
         {
@@ -45,6 +46,7 @@ namespace Hazel.Crypto
         {
             this.hash?.Dispose();
             this.hash = SHA256.Create();
+            this.isHashFinished = false;
         }
 
         /// <summary>
@@ -72,7 +74,12 @@ namespace Hazel.Crypto
                 throw new ArgumentException($"Expected a span of {DigestSize} bytes. Got a span of {output.Length} bytes", nameof(output));
             }
 
-            this.hash.TransformFinalBlock(EmptyArray.Value, 0, 0);
+            if (this.isHashFinished == false)
+            {
+                this.hash.TransformFinalBlock(EmptyArray.Value, 0, 0);
+                this.isHashFinished = true;
+            }
+
             new ByteSpan(this.hash.Hash).CopyTo(output);
         }
     }

--- a/Hazel/Dtls/DtlsConnectionListener.cs
+++ b/Hazel/Dtls/DtlsConnectionListener.cs
@@ -574,7 +574,7 @@ namespace Hazel.Dtls
 
                         // Generate verification signatures
                         ByteSpan handshakeStreamHash = new byte[Sha256Stream.DigestSize];
-                        peer.NextEpoch.VerificationStream.CalculateHash(handshakeStreamHash);
+                        peer.NextEpoch.VerificationStream.CopyOrCalculateFinalHash(handshakeStreamHash);
 
                         PrfSha256.ExpandSecret(
                             peer.NextEpoch.ClientVerification

--- a/Hazel/Dtls/DtlsUnityConnection.cs
+++ b/Hazel/Dtls/DtlsUnityConnection.cs
@@ -81,6 +81,8 @@ namespace Hazel.Dtls
             public ByteSpan CertificatePayload;
         }
 
+        protected readonly ILogger logger = null;
+
         private readonly object syncRoot = new object();
         private readonly RandomNumberGenerator random = RandomNumberGenerator.Create();
 
@@ -92,8 +94,6 @@ namespace Hazel.Dtls
         private readonly List<ByteSpan> queuedApplicationData = new List<ByteSpan>();
 
         private X509Certificate2Collection serverCertificates = new X509Certificate2Collection();
-
-        private readonly ILogger logger = null;
 
         /// <summary>
         /// Create a new instance of the DTLS connection
@@ -1115,7 +1115,18 @@ namespace Hazel.Dtls
 
             this.nextEpoch.State = HandshakeState.ExpectingChangeCipherSpec;
             this.nextEpoch.NextPacketResendTime = DateTime.UtcNow + this.handshakeResendTimeout;
+#if DEBUG
+            if (DropClientKeyExchangeFlight())
+            {
+                return;
+            }
+#endif
             base.WriteBytesToConnection(packet.GetUnderlyingArray(), packet.Length);
+        }
+
+        protected virtual bool DropClientKeyExchangeFlight()
+        {
+            return false;
         }
     }
 }

--- a/Hazel/Dtls/DtlsUnityConnection.cs
+++ b/Hazel/Dtls/DtlsUnityConnection.cs
@@ -1074,7 +1074,7 @@ namespace Hazel.Dtls
 
             // Calculate the hash of the verification stream
             ByteSpan handshakeHash = new byte[Sha256Stream.DigestSize];
-            this.nextEpoch.VerificationStream.CalculateHash(handshakeHash);
+            this.nextEpoch.VerificationStream.CopyOrCalculateFinalHash(handshakeHash);
 
             // Expand our master secret into Finished digests for the client and server
             PrfSha256.ExpandSecret(


### PR DESCRIPTION
**Expected**: When a single ClientKeyExchange packet from a client drops, the client should still be able to finish the DTLS handshake with a ClientKeyExchange resend.

**Actual**: The ClientKeyExchange resend(s) cause(s) the client hash verification to fail, leading to the following observable errors in debug mode:
`Dropping non-verified Finished Handshake from <source>`
and the following error looping on resend:
`Dropping non-ClientHello (ClientKeyExchange) message from non-peer <source>`

**Cause**: The issue was tracked to each SendClientKeyExchangeFlight changing the handshake hash because `this.nextEpoch.VerificationStream.CalculateHash(handshakeHash);` internally calls `TransformFinalBlock` each time despite the assumption that `TransformFinalBlock` is only ever called once.

**Fix**: Sha256Stream was updated with an internal flag to only finalize the hash a single time. A unit test was added that tests the single SendClientKeyExchangeFlight drop.