### PR TITLE
Alternative fix for managing HMAC-per-thread with synchronized key

### DIFF
--- a/Hazel/Dtls/DtlsConnectionListener.cs
+++ b/Hazel/Dtls/DtlsConnectionListener.cs
@@ -1223,7 +1223,7 @@ namespace Hazel.Dtls
             DateTime now = DateTime.UtcNow;
             if (now > DtlsConnectionListener.nextCookieHmacRotation)
             {
-                DtlsConnectionListener.previousCookieHmac?.Dispose();
+                DtlsConnectionListener.previousCookieHmac.Dispose();
                 DtlsConnectionListener.previousCookieHmac = DtlsConnectionListener.currentCookieHmac;
                 DtlsConnectionListener.currentCookieHmac = CreateNewCookieHMAC();
                 DtlsConnectionListener.nextCookieHmacRotation = now + CookieHmacRotationTimeout;

--- a/Hazel/Dtls/Handshake.cs
+++ b/Hazel/Dtls/Handshake.cs
@@ -481,9 +481,12 @@ namespace Hazel.Dtls
                 data[ii] = address[ii];
             }
 
-            ///NOTE(mendsley): Lame that we need to allocate+copy here
-            ByteSpan signature = hmac.ComputeHash(data);
-            return signature.Slice(0, CookieSize);
+            lock (hmac)
+            {
+                ///NOTE(mendsley): Lame that we need to allocate+copy here
+                ByteSpan signature = hmac.ComputeHash(data);
+                return signature.Slice(0, CookieSize);
+            }
         }
 
         /// <summary>

--- a/Hazel/Dtls/Handshake.cs
+++ b/Hazel/Dtls/Handshake.cs
@@ -481,12 +481,9 @@ namespace Hazel.Dtls
                 data[ii] = address[ii];
             }
 
-            lock (hmac)
-            {
-                ///NOTE(mendsley): Lame that we need to allocate+copy here
-                ByteSpan signature = hmac.ComputeHash(data);
-                return signature.Slice(0, CookieSize);
-            }
+            ///NOTE(mendsley): Lame that we need to allocate+copy here
+            ByteSpan signature = hmac.ComputeHash(data);
+            return signature.Slice(0, CookieSize);
         }
 
         /// <summary>

--- a/Hazel/Dtls/ThreadedHmacHelper.cs
+++ b/Hazel/Dtls/ThreadedHmacHelper.cs
@@ -1,0 +1,132 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Security.Cryptography;
+using System.Threading;
+
+namespace Hazel.Dtls
+{
+    internal class ThreadedHmacHelper : IDisposable
+    {
+        private static readonly TimeSpan CookieHmacRotationTimeout = TimeSpan.FromHours(1.0);
+
+        private readonly ILogger logger;
+        private readonly ConcurrentDictionary<int, HMAC> currentHmacs;
+        private readonly ConcurrentDictionary<int, HMAC> previousHmacs;
+
+        private DateTime nextCookieHmacRotation;
+
+        public ThreadedHmacHelper(ILogger logger)
+        {
+            this.currentHmacs = new ConcurrentDictionary<int, HMAC>();
+            this.previousHmacs = new ConcurrentDictionary<int, HMAC>();
+            this.nextCookieHmacRotation = DateTime.UtcNow + CookieHmacRotationTimeout;
+
+            this.logger = logger;
+        }
+
+        /// <summary>
+        /// [ThreadSafe] Get the current cookie hmac for the current thread.
+        /// </summary>
+        public HMAC GetCurrentCookieHmacsForThread()
+        {
+            int threadId = Thread.CurrentThread.ManagedThreadId;
+            RotateKeys(threadId);
+
+            if (!this.currentHmacs.TryGetValue(threadId, out HMAC currentCookieHmac))
+            {
+                currentCookieHmac = CreateNewCookieHMAC();
+                if (!this.currentHmacs.TryAdd(threadId, currentCookieHmac))
+                {
+                    this.logger.WriteError($"Cannot add currentCookieHmac to currentHmacs! - Should never happen - should be accessed only by a single thread");
+                }
+            }
+
+            return currentCookieHmac;
+        }
+
+        /// <summary>
+        /// [ThreadSafe] Get the previous cookie hmac for the current thread.
+        /// </summary>
+        public HMAC GetPreviousCookieHmacsForThread()
+        {
+            int threadId = Thread.CurrentThread.ManagedThreadId;
+            RotateKeys(threadId);
+
+            if (!this.previousHmacs.TryGetValue(threadId, out HMAC previousCookieHmac))
+            {
+                previousCookieHmac = CreateNewCookieHMAC();
+                if (!this.previousHmacs.TryAdd(threadId, previousCookieHmac))
+                {
+                    this.logger.WriteError($"Cannot add previousCookieHmac to previousHmacs! - Should never happen - should be accessed only by a single thread");
+                }
+            }
+
+            return previousCookieHmac;
+        }
+
+        public void Dispose()
+        {
+            foreach (var threadIdToHmac in this.currentHmacs)
+            {
+                threadIdToHmac.Value.Dispose();
+            }
+
+            this.currentHmacs.Clear();
+
+            foreach (var threadIdToHmac in this.previousHmacs)
+            {
+                threadIdToHmac.Value.Dispose();
+            }
+
+            this.previousHmacs.Clear();
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="threadId">Managed thread Id of thread calling this method.</param>
+        private void RotateKeys(int threadId)
+        {
+            // Do we need to rotate the HMAC key?
+            DateTime now = DateTime.UtcNow;
+            if (now <= this.nextCookieHmacRotation)
+            {
+                return;
+            }
+
+            if (this.previousHmacs.TryRemove(threadId, out HMAC previousHmac)) 
+            {
+                previousHmac.Dispose();
+            }
+
+            if (!this.currentHmacs.TryGetValue(threadId, out HMAC currentHmac))
+            {
+                currentHmac = CreateNewCookieHMAC();
+                this.logger.WriteError($"currentHmac did not exist when rotating keys - Should not happen");
+            }
+
+            if (!this.previousHmacs.TryAdd(threadId, currentHmac))
+            {
+                this.logger.WriteError($"Cannot add currentHmac to previousHmacs during rotation! - Should never happen - should be accessed only by a single thread");
+            };
+
+            currentHmac = CreateNewCookieHMAC();
+
+            if (!this.currentHmacs.TryAdd(threadId, currentHmac))
+            {
+                this.logger.WriteError($"Cannot add currentHmac to currentHmacs during rotation! - Should never happen - should be accessed only by a single thread");
+            };
+
+            this.nextCookieHmacRotation = now + CookieHmacRotationTimeout;
+        }
+
+        /// <summary>
+        /// Create a new cookie HMAC signer
+        /// </summary>
+        private static HMAC CreateNewCookieHMAC()
+        {
+            const string HMACProvider = "System.Security.Cryptography.HMACSHA1";
+            return HMAC.Create(HMACProvider);
+        }
+    }
+}

--- a/Hazel/Hazel.csproj
+++ b/Hazel/Hazel.csproj
@@ -92,6 +92,7 @@
     <Compile Include="Dtls\NullRecordProtection.cs" />
     <Compile Include="Dtls\PrfSha256.cs" />
     <Compile Include="Dtls\Record.cs" />
+    <Compile Include="Dtls\ThreadedHmacHelper.cs" />
     <Compile Include="Dtls\X25519EcdheRsaSha256.cs" />
     <Compile Include="FewerThreads\HazelThreadPool.cs" />
     <Compile Include="FewerThreads\ThreadLimitedUdpConnectionListener.cs" />


### PR DESCRIPTION
**Context**: The HMAC object is not thread-safe, but having only one HMAC object across n-threads requires locking during a frequent operation during handshake, so alternative approaches that manage an HMAC object per thread were explored. This solution provides an alternative to using the [ThreadStatic] attribute, which creates some problems during disposal and key synchronization.

**Proposed Solution**:
A helper class was added to manage the responsibility of HMAC objects and their thread distribution. The helper:
-Provides simple properties for accessing the calling thread's current HMAC objects
-Lazily initializes the thread's HMAC objects
-HMAC getters are lockless in the general case (CurrentDictionary reads)
-Manages key rotation with a timer
-Key generation uses cryptographically safe random and synchronized across all threads
-Dispose is thread-safe*

*My only critique is that, to prevent locking, I had to add another hmac rotation `hmacToDispose` as a thread might be using a `previousHmac` while a key rotation is happening (so we can't call previousHmac.Dispose() during rotation). However and regardless, this assumes that the calling threads do not hold their references to the HMAC objects for a long time, which if they did, could lead to an ObjectDisposedException