### PR TITLE
Improve stats accuracy and reduce memory usage

### DIFF
--- a/Hazel.UnitTests/Dtls/ConnectionTests.cs
+++ b/Hazel.UnitTests/Dtls/ConnectionTests.cs
@@ -115,7 +115,7 @@ IsdbLCwHYD3GVgk/D7NVxyU=
                 Assert.AreEqual(ConnectionState.Connected, connection.State);
                 Assert.IsTrue(
                     connection.Statistics.TotalBytesSent >= 500 &&
-                    connection.Statistics.TotalBytesSent <= 650,
+                    connection.Statistics.TotalBytesSent <= 675,
                     "Sent: " + connection.Statistics.TotalBytesSent
                 );
             }

--- a/Hazel.UnitTests/Dtls/ConnectionTests.cs
+++ b/Hazel.UnitTests/Dtls/ConnectionTests.cs
@@ -100,6 +100,28 @@ IsdbLCwHYD3GVgk/D7NVxyU=
         }
 
         [TestMethod]
+        public override void KeepAliveClientTest()
+        {
+            using (ThreadLimitedUdpConnectionListener listener = this.CreateListener(2, new IPEndPoint(IPAddress.Any, 4296), new TestLogger()))
+            using (UdpConnection connection = this.CreateConnection(new IPEndPoint(IPAddress.Loopback, 4296), new TestLogger()))
+            {
+                listener.Start();
+
+                connection.Connect();
+                connection.KeepAliveInterval = 100;
+
+                Thread.Sleep(1050);    //Enough time for ~10 keep alive packets
+
+                Assert.AreEqual(ConnectionState.Connected, connection.State);
+                Assert.IsTrue(
+                    connection.Statistics.TotalBytesSent >= 500 &&
+                    connection.Statistics.TotalBytesSent <= 650,
+                    "Sent: " + connection.Statistics.TotalBytesSent
+                );
+            }
+        }
+
+        [TestMethod]
         public void DtlsServerDisposeDisconnectsTest()
         {
             IPEndPoint ep = new IPEndPoint(IPAddress.Loopback, 27510);

--- a/Hazel.UnitTests/Dtls/DtlsConnectionTests.cs
+++ b/Hazel.UnitTests/Dtls/DtlsConnectionTests.cs
@@ -101,28 +101,6 @@ IsdbLCwHYD3GVgk/D7NVxyU=
         }
 
         [TestMethod]
-        public override void KeepAliveClientTest()
-        {
-            using (ThreadLimitedUdpConnectionListener listener = this.CreateListener(2, new IPEndPoint(IPAddress.Any, 4296), new TestLogger()))
-            using (UdpConnection connection = this.CreateConnection(new IPEndPoint(IPAddress.Loopback, 4296), new TestLogger()))
-            {
-                listener.Start();
-
-                connection.Connect();
-                connection.KeepAliveInterval = 100;
-
-                Thread.Sleep(1050);    //Enough time for ~10 keep alive packets
-
-                Assert.AreEqual(ConnectionState.Connected, connection.State);
-                Assert.IsTrue(
-                    connection.Statistics.TotalBytesSent >= 500 &&
-                    connection.Statistics.TotalBytesSent <= 675,
-                    "Sent: " + connection.Statistics.TotalBytesSent
-                );
-            }
-        }
-
-        [TestMethod]
         public void DtlsServerDisposeDisconnectsTest()
         {
             IPEndPoint ep = new IPEndPoint(IPAddress.Loopback, 27510);
@@ -807,9 +785,6 @@ IsdbLCwHYD3GVgk/D7NVxyU=
             }
         }
 
-        /// <summary>
-        ///     Tests the keepalive functionality from the client,
-        /// </summary>
         [TestMethod]
         public void KeepAliveClientTest()
         {
@@ -825,8 +800,8 @@ IsdbLCwHYD3GVgk/D7NVxyU=
 
                 Assert.AreEqual(ConnectionState.Connected, connection.State);
                 Assert.IsTrue(
-                    connection.Statistics.TotalBytesSent >= 30 &&
-                    connection.Statistics.TotalBytesSent <= 50,
+                    connection.Statistics.TotalBytesSent >= 500 &&
+                    connection.Statistics.TotalBytesSent <= 675,
                     "Sent: " + connection.Statistics.TotalBytesSent
                 );
             }

--- a/Hazel.UnitTests/StatisticsTests.cs
+++ b/Hazel.UnitTests/StatisticsTests.cs
@@ -11,7 +11,7 @@ namespace Hazel.UnitTests
         {
             ConnectionStatistics statistics = new ConnectionStatistics();
 
-            statistics.LogUnreliableSend(10, 11);
+            statistics.LogUnreliableSend(10);
 
             Assert.AreEqual(1, statistics.MessagesSent);
             Assert.AreEqual(1, statistics.UnreliableMessagesSent);
@@ -21,9 +21,8 @@ namespace Hazel.UnitTests
             Assert.AreEqual(0, statistics.HelloMessagesSent);
 
             Assert.AreEqual(10, statistics.DataBytesSent);
-            Assert.AreEqual(11, statistics.TotalBytesSent);
 
-            statistics.LogReliableSend(5, 8);
+            statistics.LogReliableSend(5);
 
             Assert.AreEqual(2, statistics.MessagesSent);
             Assert.AreEqual(1, statistics.UnreliableMessagesSent);
@@ -33,9 +32,8 @@ namespace Hazel.UnitTests
             Assert.AreEqual(0, statistics.HelloMessagesSent);
 
             Assert.AreEqual(15, statistics.DataBytesSent);
-            Assert.AreEqual(19, statistics.TotalBytesSent);
 
-            statistics.LogFragmentedSend(6, 10);
+            statistics.LogFragmentedSend(6);
 
             Assert.AreEqual(3, statistics.MessagesSent);
             Assert.AreEqual(1, statistics.UnreliableMessagesSent);
@@ -45,9 +43,8 @@ namespace Hazel.UnitTests
             Assert.AreEqual(0, statistics.HelloMessagesSent);
 
             Assert.AreEqual(21, statistics.DataBytesSent);
-            Assert.AreEqual(29, statistics.TotalBytesSent);
 
-            statistics.LogAcknowledgementSend(4);
+            statistics.LogAcknowledgementSend();
 
             Assert.AreEqual(4, statistics.MessagesSent);
             Assert.AreEqual(1, statistics.UnreliableMessagesSent);
@@ -57,9 +54,8 @@ namespace Hazel.UnitTests
             Assert.AreEqual(0, statistics.HelloMessagesSent);
 
             Assert.AreEqual(21, statistics.DataBytesSent);
-            Assert.AreEqual(33, statistics.TotalBytesSent);
 
-            statistics.LogHelloSend(7);
+            statistics.LogHelloSend();
 
             Assert.AreEqual(5, statistics.MessagesSent);
             Assert.AreEqual(1, statistics.UnreliableMessagesSent);
@@ -69,7 +65,6 @@ namespace Hazel.UnitTests
             Assert.AreEqual(1, statistics.HelloMessagesSent);
 
             Assert.AreEqual(21, statistics.DataBytesSent);
-            Assert.AreEqual(40, statistics.TotalBytesSent);
             
             Assert.AreEqual(0, statistics.MessagesReceived);
             Assert.AreEqual(0, statistics.UnreliableMessagesReceived);
@@ -80,6 +75,9 @@ namespace Hazel.UnitTests
 
             Assert.AreEqual(0, statistics.DataBytesReceived);
             Assert.AreEqual(0, statistics.TotalBytesReceived);
+
+            statistics.LogPacketSend(11);
+            Assert.AreEqual(11, statistics.TotalBytesSent);
         }
 
         [TestMethod]

--- a/Hazel.UnitTests/ThreadLimitedUdpConnectionTests.cs
+++ b/Hazel.UnitTests/ThreadLimitedUdpConnectionTests.cs
@@ -194,6 +194,8 @@ namespace Hazel.UnitTests
                 connection.Connect();
 
                 Assert.AreEqual(ConnectionState.Connected, connection.State);
+
+                Console.Write($"Client sent {connection.Statistics.TotalBytesSent} bytes ");
             }
         }
 
@@ -332,7 +334,7 @@ namespace Hazel.UnitTests
         ///     Tests the keepalive functionality from the client,
         /// </summary>
         [TestMethod]
-        public void KeepAliveClientTest()
+        public virtual void KeepAliveClientTest()
         {
             using (ThreadLimitedUdpConnectionListener listener = this.CreateListener(2, new IPEndPoint(IPAddress.Any, 4296), new TestLogger()))
             using (UdpConnection connection = this.CreateConnection(new IPEndPoint(IPAddress.Loopback, 4296), new TestLogger()))

--- a/Hazel/ConnectionStatistics.cs
+++ b/Hazel/ConnectionStatistics.cs
@@ -398,20 +398,21 @@ namespace Hazel
         ///     Logs the sending of an unreliable data packet in the statistics.
         /// </summary>
         /// <param name="dataLength">The number of bytes of data sent.</param>
-        /// <param name="totalLength">The total number of bytes sent.</param>
         /// <remarks>
         ///     This should be called after the data has been sent and should only be called for data that is sent sucessfully.
         /// </remarks>
-        internal void LogUnreliableSend(int dataLength, int totalLength)
+        internal void LogUnreliableSend(int dataLength)
         {
             Interlocked.Increment(ref unreliableMessagesSent);
             Interlocked.Add(ref dataBytesSent, dataLength);
-            Interlocked.Add(ref totalBytesSent, totalLength);
+            
         }
 
+        /// <param name="totalLength">The total number of bytes sent.</param>
         internal void LogPacketSend(int totalLength)
         {
             Interlocked.Increment(ref this.packetsSent);
+            Interlocked.Add(ref totalBytesSent, totalLength);
 
             if (totalLength > ExpectedMTU)
             {
@@ -423,15 +424,13 @@ namespace Hazel
         ///     Logs the sending of a reliable data packet in the statistics.
         /// </summary>
         /// <param name="dataLength">The number of bytes of data sent.</param>
-        /// <param name="totalLength">The total number of bytes sent.</param>
         /// <remarks>
         ///     This should be called after the data has been sent and should only be called for data that is sent sucessfully.
         /// </remarks>
-        internal void LogReliableSend(int dataLength, int totalLength)
+        internal void LogReliableSend(int dataLength)
         {
             Interlocked.Increment(ref reliableMessagesSent);
             Interlocked.Add(ref dataBytesSent, dataLength);
-            Interlocked.Add(ref totalBytesSent, totalLength);
         }
 
         /// <summary>
@@ -442,11 +441,10 @@ namespace Hazel
         /// <remarks>
         ///     This should be called after the data has been sent and should only be called for data that is sent sucessfully.
         /// </remarks>
-        internal void LogFragmentedSend(int dataLength, int totalLength)
+        internal void LogFragmentedSend(int dataLength)
         {
             Interlocked.Increment(ref fragmentedMessagesSent);
             Interlocked.Add(ref dataBytesSent, dataLength);
-            Interlocked.Add(ref totalBytesSent, totalLength);
         }
 
         /// <summary>
@@ -456,10 +454,9 @@ namespace Hazel
         /// <remarks>
         ///     This should be called after the data has been sent and should only be called for data that is sent sucessfully.
         /// </remarks>
-        internal void LogAcknowledgementSend(int totalLength)
+        internal void LogAcknowledgementSend()
         {
             Interlocked.Increment(ref acknowledgementMessagesSent);
-            Interlocked.Add(ref totalBytesSent, totalLength);
         }
 
         /// <summary>
@@ -469,10 +466,9 @@ namespace Hazel
         /// <remarks>
         ///     This should be called after the data has been sent and should only be called for data that is sent sucessfully.
         /// </remarks>
-        internal void LogHelloSend(int totalLength)
+        internal void LogHelloSend()
         {
             Interlocked.Increment(ref helloMessagesSent);
-            Interlocked.Add(ref totalBytesSent, totalLength);
         }
 
         /// <summary>

--- a/Hazel/FewerThreads/ThreadLimitedUdpServerConnection.cs
+++ b/Hazel/FewerThreads/ThreadLimitedUdpServerConnection.cs
@@ -45,6 +45,10 @@ namespace Hazel.Udp.FewerThreads
         {
             if (bytes.Length != length) throw new ArgumentException("I made an assumption here. I hope you see this error.");
 
+            // Hrm, well this is inaccurate for DTLS connections because the Listener does the encryption which may change the size.
+            // but I don't want to have a bunch of client references in the send queue...
+            // Does this perhaps mean the encryption is being done in the wrong class?
+            this.Statistics.LogPacketSend(length);
             Listener.SendDataRaw(bytes, EndPoint);
         }
 
@@ -85,7 +89,7 @@ namespace Hazel.Udp.FewerThreads
 
             try
             {
-                Listener.SendDataRaw(bytes, EndPoint);
+                this.WriteBytesToConnection(bytes, bytes.Length);
             }
             catch { }
 

--- a/Hazel/Udp/UdpClientConnection.cs
+++ b/Hazel/Udp/UdpClientConnection.cs
@@ -83,6 +83,7 @@ namespace Hazel.Udp
 
             try
             {
+                this.Statistics.LogPacketSend(length);
                 socket.BeginSendTo(
                     bytes,
                     0,

--- a/Hazel/Udp/UdpConnection.KeepAlive.cs
+++ b/Hazel/Udp/UdpConnection.KeepAlive.cs
@@ -136,7 +136,7 @@ namespace Hazel.Udp
         /// <summary>
         ///     Resets the keepalive timer to zero.
         /// </summary>
-        private void ResetKeepAliveTimer()
+        protected void ResetKeepAliveTimer()
         {
             try
             {

--- a/Hazel/Udp/UdpConnection.KeepAlive.cs
+++ b/Hazel/Udp/UdpConnection.KeepAlive.cs
@@ -130,7 +130,7 @@ namespace Hazel.Udp
 
             WriteBytesToConnection(bytes, bytes.Length);
 
-            Statistics.LogReliableSend(0, bytes.Length);
+            Statistics.LogReliableSend(0);
         }
 
         /// <summary>

--- a/Hazel/Udp/UdpConnection.Reliable.cs
+++ b/Hazel/Udp/UdpConnection.Reliable.cs
@@ -261,7 +261,7 @@ namespace Hazel.Udp
             //Write to connection
             WriteBytesToConnection(bytes, bytes.Length);
 
-            Statistics.LogReliableSend(data.Length, bytes.Length);
+            Statistics.LogReliableSend(data.Length);
         }
 
         /// <summary>

--- a/Hazel/Udp/UdpConnection.cs
+++ b/Hazel/Udp/UdpConnection.cs
@@ -74,12 +74,12 @@ namespace Hazel.Udp
 
                     AttachReliableID(buffer, 1);
                     WriteBytesToConnection(buffer, buffer.Length);
-                    Statistics.LogReliableSend(buffer.Length - 3, buffer.Length);
+                    Statistics.LogReliableSend(buffer.Length - 3);
                     break;
 
                 default:
                     WriteBytesToConnection(buffer, buffer.Length);
-                    Statistics.LogUnreliableSend(buffer.Length - 1, buffer.Length);
+                    Statistics.LogUnreliableSend(buffer.Length - 1);
                     break;
             }
         }
@@ -207,7 +207,7 @@ namespace Hazel.Udp
             //Write to connection
             WriteBytesToConnection(bytes, bytes.Length);
 
-            Statistics.LogUnreliableSend(length, bytes.Length);
+            Statistics.LogUnreliableSend(length);
         }
 
         /// <summary>

--- a/Hazel/Udp/UdpConnection.cs
+++ b/Hazel/Udp/UdpConnection.cs
@@ -15,6 +15,11 @@ namespace Hazel.Udp
 
         public static readonly byte[] EmptyDisconnectBytes = new byte[] { (byte)UdpSendOption.Disconnect };
 
+        public UdpConnection() : base()
+        {
+            this.PacketPool = new ObjectPool<Packet>(() => new Packet(this));
+        }
+
         internal static Socket CreateSocket(IPMode ipMode)
         {
             Socket socket;

--- a/Hazel/Udp/UdpServerConnection.cs
+++ b/Hazel/Udp/UdpServerConnection.cs
@@ -38,6 +38,7 @@ namespace Hazel.Udp
         /// <inheritdoc />
         protected override void WriteBytesToConnection(byte[] bytes, int length)
         {
+            this.Statistics.LogPacketSend(length);
             Listener.SendData(bytes, length, EndPoint);
         }
 

--- a/Hazel/Udp/UnityUdpClientConnection.cs
+++ b/Hazel/Udp/UnityUdpClientConnection.cs
@@ -8,7 +8,6 @@ namespace Hazel.Udp
 {
     /// <summary>
     /// Unity doesn't always get along with thread pools well, so this interface will hopefully suit that case better.
-    /// Be very careful since this interface is likely unstable or actively changing
     /// </summary>
     /// <inheritdoc/>
     public class UnityUdpClientConnection : UdpConnection
@@ -60,7 +59,6 @@ namespace Hazel.Udp
         protected virtual void ResendPacketsIfNeeded()
         {
         }
-
 
         /// <inheritdoc />
         protected override void WriteBytesToConnection(byte[] bytes, int length)
@@ -195,12 +193,11 @@ namespace Hazel.Udp
                 throw new HazelException("A SocketException occurred while initiating a receive operation.", e);
             }
 
-            this.InitializeKeepAliveTimer();
-
             // Write bytes to the server to tell it hi (and to punch a hole in our NAT, if present)
             // When acknowledged set the state to connected
             SendHello(bytes, () =>
             {
+                this.InitializeKeepAliveTimer();
                 this.State = ConnectionState.Connected;
             });
         }


### PR DESCRIPTION
- I moved where we submit total packet size so it's right against sending the bytes. This presents fewer opportunities to miss adding the bytes because I noticed that DTLS handshakes were never added to the total. There is one spot in server (commented) where it will won't be accurate, but it is an improvement.
- I made PacketPool non-static. If a single user were to cause a flood of packets, those packets would never be released before. Now the packet pools are isolated and released when a user disconnects. Should reduce baseline memory pressure albeit at the cost of more allocations as players connect. Also something to be said for less potential for cross-contamination or shared-resource bugs.
- I delayed starting the KeepAlive thread on clients until the connection is established. Unlikely to make a huge difference, but there is no good reason to send a ping if a connection hasn't even been established yet. The server ideally would just toss those packets anyways.