### PR TITLE
Intercept app data for DTLS earlier

### DIFF
--- a/Hazel.UnitTests/Dtls/ConnectionTests.cs
+++ b/Hazel.UnitTests/Dtls/ConnectionTests.cs
@@ -272,8 +272,6 @@ IsdbLCwHYD3GVgk/D7NVxyU=
         [TestMethod]
         public void TestMalformedConnectionData()
         {
-            Assert.Inconclusive("This test is known to fail because the connection.State remains ConnectionState.Connecting even after we time out.");
-
             IPEndPoint ep = new IPEndPoint(IPAddress.Loopback, 27510);
 
             IPEndPoint connectionEndPoint = ep;

--- a/Hazel.UnitTests/Dtls/ConnectionTests.cs
+++ b/Hazel.UnitTests/Dtls/ConnectionTests.cs
@@ -272,6 +272,8 @@ IsdbLCwHYD3GVgk/D7NVxyU=
         [TestMethod]
         public void TestMalformedConnectionData()
         {
+            Assert.Inconclusive("This test is known to fail because the connection.State remains ConnectionState.Connecting even after we time out.");
+
             IPEndPoint ep = new IPEndPoint(IPAddress.Loopback, 27510);
 
             IPEndPoint connectionEndPoint = ep;

--- a/Hazel.UnitTests/Dtls/DtlsConnectionTests.cs
+++ b/Hazel.UnitTests/Dtls/DtlsConnectionTests.cs
@@ -4,6 +4,7 @@ using Hazel.Udp.FewerThreads;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Net;
+using System.Net.Sockets;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
@@ -11,7 +12,7 @@ using System.Threading;
 namespace Hazel.UnitTests.Dtls
 {
     [TestClass]
-    public class ConnectionTests : BaseThreadLimitedUdpConnectionTests
+    public class DtlsConnectionTests
     {
         // Created with command line
         // openssl req -newkey rsa:2048 -nodes -keyout key.pem -x509 -days 100000 -out certificate.pem
@@ -84,7 +85,7 @@ IsdbLCwHYD3GVgk/D7NVxyU=
             return clientCertificates;
         }
 
-        protected override ThreadLimitedUdpConnectionListener CreateListener(int numWorkers, IPEndPoint endPoint, ILogger logger, IPMode ipMode = IPMode.IPv4)
+        protected ThreadLimitedUdpConnectionListener CreateListener(int numWorkers, IPEndPoint endPoint, ILogger logger, IPMode ipMode = IPMode.IPv4)
         {
             DtlsConnectionListener listener = new DtlsConnectionListener(2, endPoint, logger, ipMode);
             listener.SetCertificate(GetCertificateForServer());
@@ -92,7 +93,7 @@ IsdbLCwHYD3GVgk/D7NVxyU=
 
         }
 
-        protected override UdpConnection CreateConnection(IPEndPoint endPoint, ILogger logger, IPMode ipMode = IPMode.IPv4)
+        protected UdpConnection CreateConnection(IPEndPoint endPoint, ILogger logger, IPMode ipMode = IPMode.IPv4)
         {
             DtlsUnityConnection connection = new DtlsUnityConnection(logger, endPoint, ipMode);
             connection.SetValidServerCertificates(GetCertificateForClient());
@@ -483,6 +484,485 @@ IsdbLCwHYD3GVgk/D7NVxyU=
 #else
             Assert.Inconclusive("Only works in DEBUG");
 #endif
+        }
+
+        [TestMethod]
+        public void ServerDisposeDisconnectsTest()
+        {
+            IPEndPoint ep = new IPEndPoint(IPAddress.Loopback, 4296);
+
+            bool serverConnected = false;
+            bool serverDisconnected = false;
+            bool clientDisconnected = false;
+
+            using (ThreadLimitedUdpConnectionListener listener = this.CreateListener(2, new IPEndPoint(IPAddress.Any, 4296), new TestLogger("SERVER")))
+            using (UdpConnection connection = this.CreateConnection(ep, new TestLogger("CLIENT")))
+            {
+                listener.NewConnection += (evt) =>
+                {
+                    serverConnected = true;
+                    evt.Connection.Disconnected += (o, et) => serverDisconnected = true;
+                };
+                connection.Disconnected += (o, evt) => clientDisconnected = true;
+
+                listener.Start();
+                connection.Connect();
+
+                Thread.Sleep(100); // Gotta wait for the server to set up the events.
+                listener.Dispose();
+                Thread.Sleep(100);
+
+                Assert.IsTrue(serverConnected);
+                Assert.IsTrue(clientDisconnected);
+                Assert.IsFalse(serverDisconnected);
+            }
+        }
+
+        [TestMethod]
+        public void ClientDisposeDisconnectTest()
+        {
+            IPEndPoint ep = new IPEndPoint(IPAddress.Loopback, 4296);
+
+            bool serverConnected = false;
+            bool serverDisconnected = false;
+            bool clientDisconnected = false;
+
+            using (ThreadLimitedUdpConnectionListener listener = this.CreateListener(2, new IPEndPoint(IPAddress.Any, 4296), new TestLogger()))
+            using (UdpConnection connection = this.CreateConnection(ep, new TestLogger()))
+            {
+                listener.NewConnection += (evt) =>
+                {
+                    serverConnected = true;
+                    evt.Connection.Disconnected += (o, et) => serverDisconnected = true;
+                };
+
+                connection.Disconnected += (o, et) => clientDisconnected = true;
+
+                listener.Start();
+                connection.Connect();
+
+                Thread.Sleep(100); // Gotta wait for the server to set up the events.
+                connection.Dispose();
+
+                Thread.Sleep(100);
+
+                Assert.IsTrue(serverConnected);
+                Assert.IsTrue(serverDisconnected);
+                Assert.IsFalse(clientDisconnected);
+            }
+        }
+
+        /// <summary>
+        ///     Tests the fields on UdpConnection.
+        /// </summary>
+        [TestMethod]
+        public void UdpFieldTest()
+        {
+            IPEndPoint ep = new IPEndPoint(IPAddress.Loopback, 4296);
+
+            using (ThreadLimitedUdpConnectionListener listener = this.CreateListener(2, new IPEndPoint(IPAddress.Any, 4296), new TestLogger()))
+            using (UdpConnection connection = this.CreateConnection(ep, new TestLogger()))
+            {
+                listener.Start();
+
+                connection.Connect();
+
+                //Connection fields
+                Assert.AreEqual(ep, connection.EndPoint);
+
+                //UdpConnection fields
+                Assert.AreEqual(new IPEndPoint(IPAddress.Loopback, 4296), connection.EndPoint);
+                Assert.AreEqual(1, connection.Statistics.DataBytesSent);
+                Assert.AreEqual(0, connection.Statistics.DataBytesReceived);
+            }
+        }
+
+        [TestMethod]
+        public void UdpHandshakeTest()
+        {
+            byte[] TestData = new byte[] { 1, 2, 3, 4, 5, 6 };
+            using (ThreadLimitedUdpConnectionListener listener = this.CreateListener(2, new IPEndPoint(IPAddress.Any, 4296), new TestLogger()))
+            using (UdpConnection connection = this.CreateConnection(new IPEndPoint(IPAddress.Loopback, 4296), new TestLogger()))
+            {
+                listener.Start();
+
+                MessageReader output = null;
+                listener.NewConnection += delegate (NewConnectionEventArgs e)
+                {
+                    output = e.HandshakeData.Duplicate();
+                };
+
+                connection.Connect(TestData);
+
+                Thread.Sleep(10);
+                for (int i = 0; i < TestData.Length; ++i)
+                {
+                    Assert.AreEqual(TestData[i], output.ReadByte());
+                }
+            }
+        }
+
+        [TestMethod]
+        public void UdpUnreliableMessageSendTest()
+        {
+            byte[] TestData = new byte[] { 1, 2, 3, 4, 5, 6 };
+            using (ThreadLimitedUdpConnectionListener listener = this.CreateListener(2, new IPEndPoint(IPAddress.Any, 4296), new TestLogger()))
+            using (UdpConnection connection = this.CreateConnection(new IPEndPoint(IPAddress.Loopback, 4296), new TestLogger()))
+            {
+                MessageReader output = null;
+                listener.NewConnection += delegate (NewConnectionEventArgs e)
+                {
+                    e.Connection.DataReceived += delegate (DataReceivedEventArgs evt)
+                    {
+                        output = evt.Message.Duplicate();
+                    };
+                };
+
+                listener.Start();
+                connection.Connect();
+
+                for (int i = 0; i < 4; ++i)
+                {
+                    var msg = MessageWriter.Get(SendOption.None);
+                    msg.Write(TestData);
+                    connection.Send(msg);
+                    msg.Recycle();
+                }
+
+                Thread.Sleep(10);
+                for (int i = 0; i < TestData.Length; ++i)
+                {
+                    Assert.AreEqual(TestData[i], output.ReadByte());
+                }
+            }
+        }
+
+        /// <summary>
+        ///     Tests IPv4 connectivity.
+        /// </summary>
+        [TestMethod]
+        public void UdpIPv4ConnectionTest()
+        {
+            using (ThreadLimitedUdpConnectionListener listener = this.CreateListener(2, new IPEndPoint(IPAddress.Any, 4296), new TestLogger()))
+            using (UdpConnection connection = this.CreateConnection(new IPEndPoint(IPAddress.Loopback, 4296), new TestLogger()))
+            {
+                listener.Start();
+
+                connection.Connect();
+
+                Assert.AreEqual(ConnectionState.Connected, connection.State);
+            }
+        }
+
+        /// <summary>
+        ///     Tests IPv4 resilience to multiple hellos.
+        /// </summary>
+        [TestMethod]
+        public void ConnectLikeAJerkTest()
+        {
+            using (ThreadLimitedUdpConnectionListener listener = this.CreateListener(2, new IPEndPoint(IPAddress.Any, 4296), new TestLogger()))
+            using (Socket socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp))
+            {
+                int connects = 0;
+                listener.NewConnection += (obj) =>
+                {
+                    Interlocked.Increment(ref connects);
+                };
+
+                listener.Start();
+
+                socket.Bind(new IPEndPoint(IPAddress.Any, 0));
+                var bytes = new byte[2];
+                bytes[0] = (byte)UdpSendOption.Hello;
+                for (int i = 0; i < 10; ++i)
+                {
+                    socket.SendTo(bytes, new IPEndPoint(IPAddress.Loopback, 4296));
+                }
+
+                Thread.Sleep(500);
+
+                Assert.AreEqual(0, listener.ReceiveQueueLength);
+                Assert.IsTrue(connects <= 1, $"Too many connections: {connects}");
+            }
+        }
+
+        /// <summary>
+        ///     Tests dual mode connectivity.
+        /// </summary>
+        [TestMethod]
+        public void MixedConnectionTest()
+        {
+
+            using (ThreadLimitedUdpConnectionListener listener2 = this.CreateListener(4, new IPEndPoint(IPAddress.IPv6Any, 4296), new ConsoleLogger(true), IPMode.IPv6))
+            {
+                listener2.Start();
+
+                listener2.NewConnection += (evt) =>
+                {
+                    Console.WriteLine($"Connection: {evt.Connection.EndPoint}");
+                };
+
+                using (UdpConnection connection = this.CreateConnection(new IPEndPoint(IPAddress.Parse("127.0.0.1"), 4296), new TestLogger()))
+                {
+                    connection.Connect();
+                    Assert.AreEqual(ConnectionState.Connected, connection.State);
+                }
+
+                using (UdpConnection connection2 = this.CreateConnection(new IPEndPoint(IPAddress.IPv6Loopback, 4296), new TestLogger(), IPMode.IPv6))
+                {
+                    connection2.Connect();
+                    Assert.AreEqual(ConnectionState.Connected, connection2.State);
+                }
+            }
+        }
+
+        /// <summary>
+        ///     Tests dual mode connectivity.
+        /// </summary>
+        [TestMethod]
+        public void UdpIPv6ConnectionTest()
+        {
+            using (ThreadLimitedUdpConnectionListener listener = this.CreateListener(2, new IPEndPoint(IPAddress.IPv6Any, 4296), new TestLogger(), IPMode.IPv6))
+            {
+                listener.Start();
+
+                using (UdpConnection connection = this.CreateConnection(new IPEndPoint(IPAddress.Parse("127.0.0.1"), 4296), new TestLogger(), IPMode.IPv6))
+                {
+                    connection.Connect();
+                }
+            }
+        }
+
+        /// <summary>
+        ///     Tests server to client unreliable communication on the UdpConnection.
+        /// </summary>
+        [TestMethod]
+        public void UdpUnreliableServerToClientTest()
+        {
+            using (ThreadLimitedUdpConnectionListener listener = this.CreateListener(2, new IPEndPoint(IPAddress.Any, 4296), new TestLogger()))
+            using (UdpConnection connection = this.CreateConnection(new IPEndPoint(IPAddress.Loopback, 4296), new TestLogger()))
+            {
+                TestHelper.RunServerToClientTest(listener, connection, 10, SendOption.None);
+            }
+        }
+
+        /// <summary>
+        ///     Tests server to client reliable communication on the UdpConnection.
+        /// </summary>
+        [TestMethod]
+        public void UdpReliableServerToClientTest()
+        {
+            using (ThreadLimitedUdpConnectionListener listener = this.CreateListener(2, new IPEndPoint(IPAddress.Any, 4296), new TestLogger()))
+            using (UdpConnection connection = this.CreateConnection(new IPEndPoint(IPAddress.Loopback, 4296), new TestLogger()))
+            {
+                TestHelper.RunServerToClientTest(listener, connection, 10, SendOption.Reliable);
+            }
+        }
+
+        /// <summary>
+        ///     Tests server to client unreliable communication on the UdpConnection.
+        /// </summary>
+        [TestMethod]
+        public void UdpUnreliableClientToServerTest()
+        {
+            using (ThreadLimitedUdpConnectionListener listener = this.CreateListener(2, new IPEndPoint(IPAddress.Any, 4296), new TestLogger()))
+            using (UdpConnection connection = this.CreateConnection(new IPEndPoint(IPAddress.Loopback, 4296), new TestLogger()))
+            {
+                TestHelper.RunClientToServerTest(listener, connection, 10, SendOption.None);
+            }
+        }
+
+        /// <summary>
+        ///     Tests server to client reliable communication on the UdpConnection.
+        /// </summary>
+        [TestMethod]
+        public void UdpReliableClientToServerTest()
+        {
+            using (ThreadLimitedUdpConnectionListener listener = this.CreateListener(2, new IPEndPoint(IPAddress.Any, 4296), new TestLogger()))
+            using (UdpConnection connection = this.CreateConnection(new IPEndPoint(IPAddress.Loopback, 4296), new TestLogger()))
+            {
+                TestHelper.RunClientToServerTest(listener, connection, 10, SendOption.Reliable);
+            }
+        }
+
+        /// <summary>
+        ///     Tests the keepalive functionality from the client,
+        /// </summary>
+        [TestMethod]
+        public void KeepAliveClientTest()
+        {
+            using (ThreadLimitedUdpConnectionListener listener = this.CreateListener(2, new IPEndPoint(IPAddress.Any, 4296), new TestLogger()))
+            using (UdpConnection connection = this.CreateConnection(new IPEndPoint(IPAddress.Loopback, 4296), new TestLogger()))
+            {
+                listener.Start();
+
+                connection.Connect();
+                connection.KeepAliveInterval = 100;
+
+                Thread.Sleep(1050);    //Enough time for ~10 keep alive packets
+
+                Assert.AreEqual(ConnectionState.Connected, connection.State);
+                Assert.IsTrue(
+                    connection.Statistics.TotalBytesSent >= 30 &&
+                    connection.Statistics.TotalBytesSent <= 50,
+                    "Sent: " + connection.Statistics.TotalBytesSent
+                );
+            }
+        }
+
+        /// <summary>
+        ///     Tests the keepalive functionality from the client,
+        /// </summary>
+        [TestMethod]
+        public void KeepAliveServerTest()
+        {
+            ManualResetEvent mutex = new ManualResetEvent(false);
+
+            using (ThreadLimitedUdpConnectionListener listener = this.CreateListener(2, new IPEndPoint(IPAddress.Any, 4296), new TestLogger()))
+            using (UdpConnection connection = this.CreateConnection(new IPEndPoint(IPAddress.Loopback, 4296), new TestLogger()))
+            {
+                UdpConnection client = null;
+                listener.NewConnection += delegate (NewConnectionEventArgs args)
+                {
+                    client = (UdpConnection)args.Connection;
+                    client.KeepAliveInterval = 100;
+
+                    Thread timeoutThread = new Thread(() =>
+                    {
+                        Thread.Sleep(1050);    //Enough time for ~10 keep alive packets
+                        mutex.Set();
+                    });
+                    timeoutThread.Start();
+                };
+
+                listener.Start();
+
+                connection.Connect();
+
+                mutex.WaitOne();
+
+                Assert.AreEqual(ConnectionState.Connected, client.State);
+
+                Assert.IsTrue(
+                    client.Statistics.TotalBytesSent >= 27 &&
+                    client.Statistics.TotalBytesSent <= 50,
+                    "Sent: " + client.Statistics.TotalBytesSent
+                );
+            }
+        }
+
+        /// <summary>
+        ///     Tests disconnection from the client.
+        /// </summary>
+        [TestMethod]
+        public void ClientDisconnectTest()
+        {
+            using (ThreadLimitedUdpConnectionListener listener = this.CreateListener(2, new IPEndPoint(IPAddress.Any, 4296), new TestLogger()))
+            using (UdpConnection connection = this.CreateConnection(new IPEndPoint(IPAddress.Loopback, 4296), new TestLogger()))
+            {
+                ManualResetEvent mutex = new ManualResetEvent(false);
+                ManualResetEvent mutex2 = new ManualResetEvent(false);
+
+                listener.NewConnection += delegate (NewConnectionEventArgs args)
+                {
+                    args.Connection.Disconnected += delegate (object sender2, DisconnectedEventArgs args2)
+                    {
+                        mutex2.Set();
+                    };
+
+                    mutex.Set();
+                };
+
+                listener.Start();
+
+                connection.Connect();
+
+                mutex.WaitOne();
+
+                connection.Disconnect("Testing");
+
+                mutex2.WaitOne();
+            }
+        }
+
+        /// <summary>
+        ///     Tests disconnection from the server.
+        /// </summary>
+        [TestMethod]
+        public void ServerDisconnectTest()
+        {
+            using (ThreadLimitedUdpConnectionListener listener = this.CreateListener(2, new IPEndPoint(IPAddress.Any, 4296), new TestLogger()))
+            using (UdpConnection connection = this.CreateConnection(new IPEndPoint(IPAddress.Loopback, 4296), new TestLogger()))
+            {
+                SemaphoreSlim mutex = new SemaphoreSlim(0, 100);
+                ManualResetEventSlim serverMutex = new ManualResetEventSlim(false);
+
+                connection.Disconnected += delegate (object sender, DisconnectedEventArgs args)
+                {
+                    mutex.Release();
+                };
+
+                listener.NewConnection += delegate (NewConnectionEventArgs args)
+                {
+                    mutex.Release();
+
+                    // This has to be on a new thread because the client will go straight from Connecting to NotConnected
+                    ThreadPool.QueueUserWorkItem(_ =>
+                    {
+                        serverMutex.Wait(500);
+                        args.Connection.Disconnect("Testing");
+                    });
+                };
+
+                listener.Start();
+
+                connection.Connect();
+
+                mutex.Wait(500);
+                Assert.AreEqual(ConnectionState.Connected, connection.State);
+
+                serverMutex.Set();
+
+                mutex.Wait(500);
+                Assert.AreEqual(ConnectionState.NotConnected, connection.State);
+            }
+        }
+
+        /// <summary>
+        ///     Tests disconnection from the server.
+        /// </summary>
+        [TestMethod]
+        public void ServerExtraDataDisconnectTest()
+        {
+            using (ThreadLimitedUdpConnectionListener listener = this.CreateListener(2, new IPEndPoint(IPAddress.Any, 4296), new TestLogger()))
+            using (UdpConnection connection = this.CreateConnection(new IPEndPoint(IPAddress.Loopback, 4296), new TestLogger()))
+            {
+                string received = null;
+                ManualResetEvent mutex = new ManualResetEvent(false);
+
+                connection.Disconnected += delegate (object sender, DisconnectedEventArgs args)
+                {
+                    // We don't own the message, we have to read the string now
+                    received = args.Message.ReadString();
+                    mutex.Set();
+                };
+
+                listener.NewConnection += delegate (NewConnectionEventArgs args)
+                {
+                    MessageWriter writer = MessageWriter.Get(SendOption.None);
+                    writer.Write("Goodbye");
+                    args.Connection.Disconnect("Testing", writer);
+                };
+
+                listener.Start();
+
+                connection.Connect();
+
+                mutex.WaitOne(5000);
+
+                Assert.IsNotNull(received);
+                Assert.AreEqual("Goodbye", received);
+            }
         }
     }
 }

--- a/Hazel.UnitTests/ThreadLimitedUdpConnectionTests.cs
+++ b/Hazel.UnitTests/ThreadLimitedUdpConnectionTests.cs
@@ -11,23 +11,17 @@ using System.Collections;
 namespace Hazel.UnitTests
 {
     [TestClass]
-    public class ThreadLimitedUdpConnectionTests : BaseThreadLimitedUdpConnectionTests
+    public class ThreadLimitedUdpConnectionTests
     {
-        protected override ThreadLimitedUdpConnectionListener CreateListener(int numWorkers, IPEndPoint endPoint, ILogger logger, IPMode ipMode = IPMode.IPv4)
+        protected ThreadLimitedUdpConnectionListener CreateListener(int numWorkers, IPEndPoint endPoint, ILogger logger, IPMode ipMode = IPMode.IPv4)
         {
             return new ThreadLimitedUdpConnectionListener(numWorkers, endPoint, logger, ipMode);
         }
 
-        protected override UdpConnection CreateConnection(IPEndPoint endPoint, ILogger logger, IPMode ipMode = IPMode.IPv4)
+        protected UdpConnection CreateConnection(IPEndPoint endPoint, ILogger logger, IPMode ipMode = IPMode.IPv4)
         {
             return new UdpClientConnection(endPoint, ipMode);
         }
-    }
-
-    public abstract class BaseThreadLimitedUdpConnectionTests
-    {
-        protected abstract ThreadLimitedUdpConnectionListener CreateListener(int numWorkers, IPEndPoint endPoint, ILogger logger, IPMode ipMode = IPMode.IPv4);
-        protected abstract UdpConnection CreateConnection(IPEndPoint endPoint, ILogger logger, IPMode ipMode = IPMode.IPv4);
 
         [TestMethod]
         public void ServerDisposeDisconnectsTest()

--- a/Hazel/Dtls/DtlsUnityConnection.cs
+++ b/Hazel/Dtls/DtlsUnityConnection.cs
@@ -64,7 +64,7 @@ namespace Hazel.Dtls
 
             public ulong NextOutgoingSequence;
 
-            public DateTime NegotationStartTime;
+            public DateTime NegotiationStartTime;
             public DateTime NextPacketResendTime;
             public int PacketResendCount;
 
@@ -177,7 +177,7 @@ namespace Hazel.Dtls
             this.nextEpoch.Epoch = 1;
             this.nextEpoch.State = HandshakeState.Initializing;
             this.nextEpoch.NextOutgoingSequence = 1;
-            this.nextEpoch.NegotationStartTime = DateTime.MinValue;
+            this.nextEpoch.NegotiationStartTime = DateTime.MinValue;
             this.nextEpoch.NextPacketResendTime = DateTime.MinValue;
             this.nextEpoch.SelectedCipherSuite = CipherSuite.TLS_NULL_WITH_NULL_NULL;
             this.nextEpoch.RecordProtection?.Dispose();
@@ -225,13 +225,13 @@ namespace Hazel.Dtls
                     DateTime now = DateTime.UtcNow;
                     if (now >= this.nextEpoch.NextPacketResendTime)
                     {
-                        double negotationDuration = (now - this.nextEpoch.NegotationStartTime).TotalMilliseconds;
+                        double negotiationDurationMs = (now - this.nextEpoch.NegotiationStartTime).TotalMilliseconds;
                         this.nextEpoch.PacketResendCount++;
 
                         if ((this.ResendLimit > 0 && this.nextEpoch.PacketResendCount > this.ResendLimit)
-                            || negotationDuration > this.DisconnectTimeout)
+                            || negotiationDurationMs > this.DisconnectTimeoutMs)
                         {
-                            this.DisconnectInternal(HazelInternalErrors.DtlsNegotiationFailed, $"DTLS negotiation failed after {this.nextEpoch.PacketResendCount} resends ({(int)negotationDuration} ms).");
+                            this.DisconnectInternal(HazelInternalErrors.DtlsNegotiationFailed, $"DTLS negotiation failed after {this.nextEpoch.PacketResendCount} resends ({(int)negotiationDurationMs} ms).");
                         }
                         else
                         {
@@ -841,7 +841,7 @@ namespace Hazel.Dtls
 
                         ++this.nextEpoch.Epoch;
                         this.nextEpoch.State = HandshakeState.Established;
-                        this.nextEpoch.NegotationStartTime = DateTime.MinValue;
+                        this.nextEpoch.NegotiationStartTime = DateTime.MinValue;
                         this.nextEpoch.NextPacketResendTime = DateTime.MinValue;
                         this.nextEpoch.ServerVerification.SecureClear();
                         this.nextEpoch.MasterSecret.SecureClear();
@@ -925,7 +925,7 @@ namespace Hazel.Dtls
             );
 
             this.nextEpoch.State = HandshakeState.ExpectingServerHello;
-            if (this.nextEpoch.NegotationStartTime == DateTime.MinValue) this.nextEpoch.NegotationStartTime = DateTime.UtcNow;
+            if (this.nextEpoch.NegotiationStartTime == DateTime.MinValue) this.nextEpoch.NegotiationStartTime = DateTime.UtcNow;
             this.nextEpoch.NextPacketResendTime = DateTime.UtcNow + this.handshakeResendTimeout;
             base.WriteBytesToConnection(packet.GetUnderlyingArray(), packet.Length);
         }
@@ -986,7 +986,7 @@ namespace Hazel.Dtls
             );
 
             this.nextEpoch.State = HandshakeState.ExpectingServerHello;
-            if (this.nextEpoch.NegotationStartTime == DateTime.MinValue) this.nextEpoch.NegotationStartTime = DateTime.UtcNow;
+            if (this.nextEpoch.NegotiationStartTime == DateTime.MinValue) this.nextEpoch.NegotiationStartTime = DateTime.UtcNow;
             this.nextEpoch.NextPacketResendTime = DateTime.UtcNow + this.handshakeResendTimeout;
             base.WriteBytesToConnection(packet.GetUnderlyingArray(), packet.Length);
         }

--- a/Hazel/Extensions.cs
+++ b/Hazel/Extensions.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections.Generic;
+
+namespace Hazel
+{
+    public static class Extensions
+    {
+        public static bool TryDequeue<T>(this Queue<T> self, out T item)
+        {
+            if (self.Count > 0)
+            {
+                item = self.Dequeue();
+                return true;
+            }
+
+            item = default;
+            return false;
+        }
+    }
+}

--- a/Hazel/NetworkConnection.cs
+++ b/Hazel/NetworkConnection.cs
@@ -14,7 +14,8 @@ namespace Hazel
         ReceivedZeroBytes,
         PingsWithoutResponse,
         ReliablePacketWithoutResponse,
-        ConnectionDisconnected
+        ConnectionDisconnected,
+        DtlsNegotiationFailed
     }
 
     /// <summary>

--- a/Hazel/Udp/UdpConnection.cs
+++ b/Hazel/Udp/UdpConnection.cs
@@ -101,7 +101,7 @@ namespace Hazel.Udp
         /// <param name="sendOption">The <see cref="SendOption"/> specified as its byte value.</param>
         /// <param name="ackCallback">The callback to invoke when this packet is acknowledged.</param>
         /// <returns>The bytes that should actually be sent.</returns>
-        protected void HandleSend(byte[] data, byte sendOption, Action ackCallback = null)
+        protected virtual void HandleSend(byte[] data, byte sendOption, Action ackCallback = null)
         {
             switch (sendOption)
             {


### PR DESCRIPTION
We were intercepting bytes at WriteBytesToConnection, which is too late to avoid starting resend timers for reliable messages. Also I'm wondering if the messages might accidentally be encrypted wrong? Like using the previous cypher if we have to renegotiate in the middle of a connection.

This is a draft because there is one failing test that needs to be fixed, but I wanted to get some feedback on what's happening and the logic of said failing test.

TestMalformedConnectionData is the only failing test because the DTLS was relying on the UDP hello packet timing out to fail the Connect. While it's important that after Connect times out, we need to stop sending packets and set the connection to NotConnecting (failure to connect). It seems... double bad? that we were relying on that kind of failure when the DTLS handshake itself has nothing to do with the underlying hello packets.

In short, I'm going to continue to poke around for a good way to have DTLS bubble up a failure to connect, but I wanted to flag this as kind of a weird thing. It's very elegant that DTLS sits on top of the UDP layer and doesn't care about the underlying send or retry mechanisms, but it also means that it needs to recreate some of those mechanisms, which it might not be doing right now.

Edit + Ready for Review: Okay, so adding timeout checks on the handshake resends seems pretty adequate. The one test is fixed, but I'm mostly left with the feeling that the testing is inadequate, but things are okay other than my anxiety.