### PR TITLE
Fix two ClientHello issues and improve debug logging

### DIFF
--- a/Hazel.UnitTests/SocketCapture.cs
+++ b/Hazel.UnitTests/SocketCapture.cs
@@ -94,9 +94,9 @@ namespace Hazel.UnitTests
             {
                 IPEndPoint fromEndPoint = new IPEndPoint(IPAddress.Any, 0);
 
-                byte[] buffer = new byte[2000];
                 for (; ; )
                 {
+                    byte[] buffer = new byte[2000];
                     EndPoint endPoint = fromEndPoint;
                     int read = this.captureSocket.ReceiveFrom(buffer, ref endPoint);
                     if (read > 0)

--- a/Hazel.UnitTests/ThreadLimitedUdpConnectionTests.cs
+++ b/Hazel.UnitTests/ThreadLimitedUdpConnectionTests.cs
@@ -416,11 +416,13 @@ namespace Hazel.UnitTests
 
                 connection.Connect();
 
-                mutex.WaitOne();
+                mutex.WaitOne(1000);
+                Assert.AreEqual(ConnectionState.Connected, connection.State);
 
                 connection.Disconnect("Testing");
 
-                mutex2.WaitOne();
+                mutex2.WaitOne(1000);
+                Assert.AreEqual(ConnectionState.NotConnected, connection.State);
             }
         }
 

--- a/Hazel/ByteSpan.cs
+++ b/Hazel/ByteSpan.cs
@@ -164,6 +164,11 @@ namespace Hazel
             return result;
         }
 
+        public override string ToString()
+        {
+            return string.Join("", this.ToArray());
+        }
+
         /// <summary>
         /// Implicit conversion from byte[] -> ByteSpan
         /// </summary>

--- a/Hazel/Dtls/DtlsConnectionListener.cs
+++ b/Hazel/Dtls/DtlsConnectionListener.cs
@@ -27,8 +27,7 @@ namespace Hazel.Dtls
             ExpectingHello,
             ExpectingClientKeyExchange,
             ExpectingChangeCipherSpec,
-            ExpectingFinish,
-            Established
+            ExpectingFinish
         }
 
         /// <summary>
@@ -472,7 +471,7 @@ namespace Hazel.Dtls
                             peer.NextEpoch.ClientVerification.CopyTo(peer.CurrentEpoch.ExpectedClientFinishedVerification);
                             peer.NextEpoch.ServerVerification.CopyTo(peer.CurrentEpoch.ServerFinishedVerification);
 
-                            peer.NextEpoch.State = HandshakeState.Established;
+                            peer.NextEpoch.State = HandshakeState.ExpectingHello;
                             peer.NextEpoch.Handshake?.Dispose();
                             peer.NextEpoch.Handshake = null;
                             peer.NextEpoch.NextOutgoingSequence = 1;
@@ -660,7 +659,7 @@ namespace Hazel.Dtls
                         }
                         // Cannot process a Finished message when we
                         // are negotiating the next epoch
-                        else if (peer.NextEpoch.State != HandshakeState.Established)
+                        else if (peer.NextEpoch.State != HandshakeState.ExpectingHello)
                         {
                             this.Logger.WriteError($"Dropping Finished message while negotiating new epoch from `{peerAddress}`");
                             continue;
@@ -1281,7 +1280,7 @@ namespace Hazel.Dtls
             lock (peer)
             {
                 // If we're negotiating a new epoch, queue data
-                if (peer.Epoch == 0 || peer.NextEpoch.State != HandshakeState.Established)
+                if (peer.Epoch == 0 || peer.NextEpoch.State != HandshakeState.ExpectingHello)
                 {
                     ByteSpan copyOfSpan = new byte[span.Length];
                     span.CopyTo(copyOfSpan);
@@ -1355,7 +1354,7 @@ namespace Hazel.Dtls
                 PeerData peer = kvp.Value;
                 lock (peer)
                 {
-                    if (peer.Epoch == 0 || peer.NextEpoch.State != HandshakeState.Established)
+                    if (peer.Epoch == 0 || peer.NextEpoch.State != HandshakeState.ExpectingHello)
                     {
                         TimeSpan negotiationAge = now - peer.StartOfNegotiation;
                         if (negotiationAge > maxAge)

--- a/Hazel/Dtls/DtlsUnityConnection.cs
+++ b/Hazel/Dtls/DtlsUnityConnection.cs
@@ -598,7 +598,6 @@ namespace Hazel.Dtls
                         if (this.nextEpoch.Cookie.Length == helloVerifyRequest.Cookie.Length
                             && Const.ConstantCompareSpans(this.nextEpoch.Cookie, helloVerifyRequest.Cookie) == 1)
                         {
-
                             this.logger.WriteError("Dropping duplicate HelloVerifyRequest handshake message");
                             continue;
                         }

--- a/Hazel/Dtls/DtlsUnityConnection.cs
+++ b/Hazel/Dtls/DtlsUnityConnection.cs
@@ -219,7 +219,7 @@ namespace Hazel.Dtls
             {
                 this.ResetConnectionState();
                 this.nextEpoch.ClientRandom.FillWithRandom(this.random);
-                this.SendClientHello(false);
+                this.SendClientHello(isRetransmit: false);
             }
 
             base.RestartConnection();
@@ -252,12 +252,12 @@ namespace Hazel.Dtls
                                 case HandshakeState.ExpectingCertificate:
                                 case HandshakeState.ExpectingServerKeyExchange:
                                 case HandshakeState.ExpectingServerHelloDone:
-                                    this.SendClientHello(true);
+                                    this.SendClientHello(isRetransmit: true);
                                     break;
 
                                 case HandshakeState.ExpectingChangeCipherSpec:
                                 case HandshakeState.ExpectingFinished:
-                                    this.SendClientKeyExchangeFlight(true);
+                                    this.SendClientKeyExchangeFlight(isRetransmit: true);
                                     break;
 
                                 case HandshakeState.Established:
@@ -607,7 +607,7 @@ namespace Hazel.Dtls
                         this.nextEpoch.ClientRandom.FillWithRandom(this.random);
 
                         // We don't need to resend here. We already have the cookie so we already sent it once.
-                        this.SendClientHello(false);
+                        this.SendClientHello(isRetransmit: false);
 
                         break;
 
@@ -844,7 +844,7 @@ namespace Hazel.Dtls
                         // Append ServerHelloDone to the verification stream
                         this.nextEpoch.VerificationStream.AddData(originalPayload);
 
-                        this.SendClientKeyExchangeFlight(false);
+                        this.SendClientKeyExchangeFlight(isRetransmit: false);
                         break;
 
                     case HandshakeType.Finished:

--- a/Hazel/Udp/UdpConnection.KeepAlive.cs
+++ b/Hazel/Udp/UdpConnection.KeepAlive.cs
@@ -140,7 +140,7 @@ namespace Hazel.Udp
         {
             try
             {
-                keepAliveTimer.Change(keepAliveInterval, keepAliveInterval);
+                keepAliveTimer?.Change(keepAliveInterval, keepAliveInterval);
             }
             catch { }
         }

--- a/Hazel/Udp/UnityUdpClientConnection.cs
+++ b/Hazel/Udp/UnityUdpClientConnection.cs
@@ -146,7 +146,7 @@ namespace Hazel.Udp
         public override void Connect(byte[] bytes = null, int timeout = 5000)
         {
             this.ConnectAsync(bytes);
-            for(int timer = 0; timer < timeout; timer += 100)
+            for (int timer = 0; timer < timeout; timer += 100)
             {
                 if (this.State != ConnectionState.Connecting) return;
                 Thread.Sleep(100);


### PR DESCRIPTION
- First bug is that when a server processes two ClientHellos for the same host, they will race and one will get stomped. This causes a memory leak from undisposed state as well as unsync'd state from the mishandled Handshake. This is 100% repro'd by DtlsConnectionTests.ConnectLikeAJerk. A double check pattern fixes this, but will affect the rate at which we can accept new connections.

- Second is that if a client sends two ClientHellos with no Cookie information, the server sends back the cookie in HelloVerifyRequest twice as well. Each HelloVerifyRequest would reset the client's ClientRandom and resend it to the server. The server would have a 50/50 chance of accepting the right ClientRandom, but won't find out until verifying the final connection. This repros very consistently by DtlsConnectionTests.ConnectLikeAJerk, but can also repro by DtlsConnectionTests.TestResentClientHelloConnects. This is fixed by not rotating the ClientRandom unless we are also rotating the Cookie.

- Bonus bug: SocketCapture was reusing its buffer which could cause torn packets during tests.
- Bonus optimization: PeerData was reset twice when created. One with defaults and immediate with real values. Not anymore.
- Various other bonus renames for clarity.