### PR TITLE
Two DTLS bug fixes and some other stuff

### DIFF
--- a/Hazel.UnitTests/Dtls/DtlsConnectionTests.cs
+++ b/Hazel.UnitTests/Dtls/DtlsConnectionTests.cs
@@ -93,7 +93,7 @@ IsdbLCwHYD3GVgk/D7NVxyU=
 
         }
 
-        protected UdpConnection CreateConnection(IPEndPoint endPoint, ILogger logger, IPMode ipMode = IPMode.IPv4)
+        protected DtlsUnityConnection CreateConnection(IPEndPoint endPoint, ILogger logger, IPMode ipMode = IPMode.IPv4)
         {
             DtlsUnityConnection connection = new DtlsUnityConnection(logger, endPoint, ipMode);
             connection.SetValidServerCertificates(GetCertificateForClient());
@@ -980,8 +980,8 @@ IsdbLCwHYD3GVgk/D7NVxyU=
         [TestMethod]
         public void ClientDisconnectTest()
         {
-            using (ThreadLimitedUdpConnectionListener listener = this.CreateListener(2, new IPEndPoint(IPAddress.Any, 4296), new TestLogger("Server")))
-            using (UdpConnection connection = this.CreateConnection(new IPEndPoint(IPAddress.Loopback, 4296), new TestLogger("Client")))
+            using (var listener = this.CreateListener(2, new IPEndPoint(IPAddress.Any, 4296), new TestLogger("Server")))
+            using (var connection = this.CreateConnection(new IPEndPoint(IPAddress.Loopback, 4296), new TestLogger("Client")))
             {
                 ManualResetEvent mutex = new ManualResetEvent(false);
                 ManualResetEvent mutex2 = new ManualResetEvent(false);

--- a/Hazel/Dtls/DtlsConnectionListener.cs
+++ b/Hazel/Dtls/DtlsConnectionListener.cs
@@ -17,7 +17,7 @@ namespace Hazel.Dtls
     /// <inheritdoc />
     public class DtlsConnectionListener : ThreadLimitedUdpConnectionListener
     {
-        private const int MaxCertFragmentSize = 600;
+        private const int MaxCertFragmentSize = 550; // Rounded down from 576, min MTU.
 
         /// <summary>
         /// Current state of handshake sequence
@@ -431,9 +431,8 @@ namespace Hazel.Dtls
                         peer.CurrentEpoch.PreviousSequenceWindowBitmask |= windowMask;
                     }
 
-#if DEBUG
+                    // This is handy for debugging, but too verbose even for verbose.
                     // this.Logger.WriteVerbose($"Record type {record.ContentType} ({peer.NextEpoch.State})");
-#endif
                     switch (record.ContentType)
                     {
                         case ContentType.ChangeCipherSpec:

--- a/Hazel/Dtls/DtlsConnectionListener.cs
+++ b/Hazel/Dtls/DtlsConnectionListener.cs
@@ -17,7 +17,7 @@ namespace Hazel.Dtls
     /// <inheritdoc />
     public class DtlsConnectionListener : ThreadLimitedUdpConnectionListener
     {
-        const int MaxDatagramSize = 1200;
+        private const int MaxCertFragmentSize = 600;
 
         /// <summary>
         /// Current state of handshake sequence
@@ -255,8 +255,8 @@ namespace Hazel.Dtls
             //  * ServerHello payload
             //  * Certificate header
             int padding = Record.Size + Handshake.Size + ServerHello.Size + Handshake.Size;
-            this.encodedCertificates.Add(certificateData.Slice(0, Math.Min(certificateData.Length, MaxDatagramSize - padding)));
-            certificateData = certificateData.Slice(Math.Min(certificateData.Length, MaxDatagramSize - padding));
+            this.encodedCertificates.Add(certificateData.Slice(0, Math.Min(certificateData.Length, MaxCertFragmentSize - padding)));
+            certificateData = certificateData.Slice(Math.Min(certificateData.Length, MaxCertFragmentSize - padding));
 
             // Subsequent certificate data needs to leave room for
             //  * Record header
@@ -264,8 +264,8 @@ namespace Hazel.Dtls
             padding = Record.Size + Handshake.Size;
             while (certificateData.Length > 0)
             {
-                this.encodedCertificates.Add(certificateData.Slice(0, Math.Min(certificateData.Length, MaxDatagramSize - padding)));
-                certificateData = certificateData.Slice(Math.Min(certificateData.Length, MaxDatagramSize - padding));
+                this.encodedCertificates.Add(certificateData.Slice(0, Math.Min(certificateData.Length, MaxCertFragmentSize - padding)));
+                certificateData = certificateData.Slice(Math.Min(certificateData.Length, MaxCertFragmentSize - padding));
             }
         }
 
@@ -432,7 +432,7 @@ namespace Hazel.Dtls
                     }
 
 #if DEBUG
-                    this.Logger.WriteVerbose($"Record type {record.ContentType} ({peer.NextEpoch.State})");
+                    // this.Logger.WriteVerbose($"Record type {record.ContentType} ({peer.NextEpoch.State})");
 #endif
                     switch (record.ContentType)
                     {
@@ -1024,7 +1024,7 @@ namespace Hazel.Dtls
                 writer = writer.Slice(Handshake.Size);
                 serverHello.Encode(writer);
                 writer = writer.Slice(ServerHello.Size);
-                certificateHandshake.Encode(writer);
+                fullCeritficateHandshake.Encode(writer);
                 writer = writer.Slice(Handshake.Size);
 
                 peer.NextEpoch.VerificationStream.AddData(packet);

--- a/Hazel/Dtls/DtlsUnityConnection.cs
+++ b/Hazel/Dtls/DtlsUnityConnection.cs
@@ -1,4 +1,3 @@
-using Hazel;
 using Hazel.Crypto;
 using Hazel.Udp;
 using System;
@@ -461,9 +460,8 @@ namespace Hazel.Dtls
                     this.currentEpoch.PreviousSequenceWindowBitmask |= windowMask;
                 }
 
-#if DEBUG
-                this.logger.WriteVerbose($"Content type was {record.ContentType} ({this.nextEpoch.State})");
-#endif
+                // This is handy for debugging, but too verbose even for verbose.
+                // this.logger.WriteVerbose($"Content type was {record.ContentType} ({this.nextEpoch.State})");
                 switch (record.ContentType)
                 {
                     case ContentType.ChangeCipherSpec:

--- a/Hazel/Dtls/DtlsUnityConnection.cs
+++ b/Hazel/Dtls/DtlsUnityConnection.cs
@@ -552,26 +552,41 @@ namespace Hazel.Dtls
                 }
                 message = message.Slice(Handshake.Size);
 
-                if (message.Length < handshake.Length)
+                // Check for fragmented messages
+                if (handshake.FragmentOffset != 0 || handshake.FragmentLength != handshake.Length)
                 {
-                    this.logger.WriteError($"Dropping malformed handshake message: AvailableBytes({message.Length}) Size({handshake.Length})");
-                    return false;
+                    // We only support fragmentation on Certificate messages
+                    if (handshake.MessageType != HandshakeType.Certificate)
+                    {
+                        this.logger.WriteError($"Dropping fragmented handshake message Type({handshake.MessageType}) Offset({handshake.FragmentOffset}) FragmentLength({handshake.FragmentLength}) Length({handshake.Length})");
+                        continue;
+                    }
+
+                    if (message.Length < handshake.FragmentLength)
+                    {
+                        this.logger.WriteError($"Dropping malformed fragmented handshake message: AvailableBytes({message.Length}) Size({handshake.FragmentLength})");
+                        return false;
+                    }
+
+                    originalPayload = originalPayload.Slice(0, (int)(Handshake.Size + handshake.FragmentLength));
+                    message = message.Slice((int)handshake.FragmentLength);
+                }
+                else
+                {
+                    if (message.Length < handshake.Length)
+                    {
+                        this.logger.WriteError($"Dropping malformed handshake message: AvailableBytes({message.Length}) Size({handshake.Length})");
+                        return false;
+                    }
+
+                    originalPayload = originalPayload.Slice(0, (int)(Handshake.Size + handshake.Length));                    
+                    message = message.Slice((int)handshake.Length);
                 }
 
-                originalPayload = originalPayload.Slice(0, (int)(Handshake.Size + handshake.Length));
                 ByteSpan payload = originalPayload.Slice(Handshake.Size);
-                message = message.Slice((int)handshake.Length);
-
-                // We only support fragmented Certificate messages
-                // from the server
-                if (handshake.MessageType != HandshakeType.Certificate && (handshake.FragmentOffset != 0 || handshake.FragmentLength != handshake.Length))
-                {
-                    this.logger.WriteError($"Dropping fragmented handshake message Type({handshake.MessageType}) Offset({handshake.FragmentOffset}) FragmentLength({handshake.FragmentLength}) Length({handshake.Length})");
-                    continue;
-                }
 
 #if DEBUG
-                this.logger.WriteVerbose($"Handshake record was {handshake.MessageType} ({this.nextEpoch.State})");
+                this.logger.WriteVerbose($"Handshake record was {handshake.MessageType} (Frag: {handshake.FragmentOffset}) ({this.nextEpoch.State})");
 #endif
                 switch (handshake.MessageType)
                 {
@@ -740,7 +755,7 @@ namespace Hazel.Dtls
                         fullCertificateHandhake.FragmentOffset = 0;
                         fullCertificateHandhake.FragmentLength = fullCertificateHandhake.Length;
 
-                        byte[] serializedCertificateHandshake = new byte[Handshake.Size];
+                        ByteSpan serializedCertificateHandshake = new byte[Handshake.Size];
                         fullCertificateHandhake.Encode(serializedCertificateHandshake);
                         this.nextEpoch.VerificationStream.AddData(serializedCertificateHandshake);
                         this.nextEpoch.VerificationStream.AddData(payload);

--- a/Hazel/Extensions.cs
+++ b/Hazel/Extensions.cs
@@ -4,6 +4,14 @@ namespace Hazel
 {
     public static class Extensions
     {
+        public static int ClampToInt(this float value, int min, int max)
+        {
+            int output = (int)value;
+            if (output < min) output = min;
+            else if (output > max) output = max;
+            return output;
+        }
+
         public static bool TryDequeue<T>(this Queue<T> self, out T item)
         {
             if (self.Count > 0)

--- a/Hazel/MessageReader.cs
+++ b/Hazel/MessageReader.cs
@@ -154,7 +154,6 @@ namespace Hazel
 
             var output = MessageReader.GetSized(len);
 
-            output.Parent = this;
             Array.Copy(this.Buffer, this.readHead, output.Buffer, 0, len);
 
             output.Length = len;


### PR DESCRIPTION
Fixes two bugs in DTLS and adjusts a constant:
 - MaxDatagramPacket is used for pre-fragmenting certificates during the DTLS handshake process. But 1200 is too large to actually do any fragmenting, so that is reduced to 600.
 - When certificates are fragmented, DtlsConnectionListener uses the wrong size for buffer overflow. The full cert length is in the Length field, and FragmentLength is the expected length.
 - While calculating verify data, DtlsConnectionListener uses the wrong handshake instance, so if the cert is fragmented, FragmentLength mismatches between client and server and a connection cannot verify later on.

Unrelated changes I hadn't committed:
Clarified and improved tracking and reporting of ping. Historically, loopback connections would nearly infinite loop because resends would spam at 0ms or 1ms ping if the "remote" didn't handle every single packet perfectly. To fix this, I lazily capped min-ping at 50ms. This fixes it better by separating reported ping from min-resend-delay.