### PR TITLE
Repurpose DTLS session info for Hazel session info.

### DIFF
--- a/Hazel.UnitTests/Dtls/DtlsConnectionTests.cs
+++ b/Hazel.UnitTests/Dtls/DtlsConnectionTests.cs
@@ -727,6 +727,21 @@ IsdbLCwHYD3GVgk/D7NVxyU=
             }
         }
 
+        [TestMethod]
+        public void DtlsSessionV0ConnectionTest()
+        {
+            using (ThreadLimitedUdpConnectionListener listener = this.CreateListener(2, new IPEndPoint(IPAddress.Any, 4296), new TestLogger()))
+            using (DtlsUnityConnection connection = this.CreateConnection(new IPEndPoint(IPAddress.Loopback, 4296), new TestLogger()))
+            {
+                connection.HazelSessionVersion = 0;
+                listener.Start();
+
+                connection.Connect();
+
+                Assert.AreEqual(ConnectionState.Connected, connection.State);
+            }
+        }
+
         private class MultipleClientHelloDtlsConnection : DtlsUnityConnection
         {
             public MultipleClientHelloDtlsConnection(ILogger logger, IPEndPoint remoteEndPoint, IPMode ipMode = IPMode.IPv4) : base(logger, remoteEndPoint, ipMode)

--- a/Hazel.UnitTests/Dtls/DtlsConnectionTests.cs
+++ b/Hazel.UnitTests/Dtls/DtlsConnectionTests.cs
@@ -313,6 +313,79 @@ IsdbLCwHYD3GVgk/D7NVxyU=
             }
         }
 
+
+        [TestMethod]
+        public void TestReorderedCertFragmentsConnects()
+        {
+            IPEndPoint captureEndPoint = new IPEndPoint(IPAddress.Loopback, 27511);
+            IPEndPoint listenerEndPoint = new IPEndPoint(IPAddress.Loopback, 27510);
+
+            bool serverConnected = false;
+            bool serverDisconnected = false;
+            bool clientDisconnected = false;
+
+            Semaphore signal = new Semaphore(0, int.MaxValue);
+
+            var logger = new TestLogger("Throttle");
+
+            using (SocketCapture capture = new SocketCapture(captureEndPoint, listenerEndPoint, logger))
+            using (DtlsConnectionListener listener = new DtlsConnectionListener(2, new IPEndPoint(IPAddress.Any, listenerEndPoint.Port), new TestLogger("Server")))
+            using (DtlsUnityConnection connection = new DtlsUnityConnection(new TestLogger("Client "), captureEndPoint))
+            {
+                Semaphore listenerToConnectionThrottle = new Semaphore(0, int.MaxValue);
+                capture.SendToLocalSemaphore = listenerToConnectionThrottle;
+                Thread throttleThread = new Thread(() => {
+                    // HelloVerifyRequest
+                    capture.AssertPacketsToLocalCountEquals(1);
+                    listenerToConnectionThrottle.Release(1);
+
+                    // ServerHello, Server Certificate (Fragment)
+                    // Server Cert
+                    // ServerKeyExchange, ServerHelloDone
+                    capture.AssertPacketsToLocalCountEquals(3);
+                    capture.ReorderPacketsForLocal(list => list.Swap(0, 1));
+                    listenerToConnectionThrottle.Release(3);
+
+                    // From here, either we recover or we don't.
+                    capture.SendToLocalSemaphore = null;
+                    listenerToConnectionThrottle.Release(int.MaxValue);
+                });
+                throttleThread.Start();
+
+                listener.SetCertificate(GetCertificateForServer());
+                connection.SetValidServerCertificates(GetCertificateForClient());
+
+                listener.NewConnection += (evt) =>
+                {
+                    serverConnected = true;
+                    signal.Release();
+                    evt.Connection.Disconnected += (o, et) => {
+                        serverDisconnected = true;
+                    };
+                };
+                connection.Disconnected += (o, evt) => {
+                    clientDisconnected = true;
+                    signal.Release();
+                };
+
+                listener.Start();
+                connection.Connect();
+
+                // wait for the client to connect
+                signal.WaitOne(10);
+
+                listener.Dispose();
+
+                // wait for the client to disconnect
+                signal.WaitOne(100);
+
+                Assert.IsTrue(serverConnected);
+                Assert.IsTrue(clientDisconnected);
+                Assert.IsFalse(serverDisconnected);
+            }
+        }
+
+
         [TestMethod]
         public void TestResentClientHelloConnects()
         {
@@ -325,7 +398,9 @@ IsdbLCwHYD3GVgk/D7NVxyU=
 
             Semaphore signal = new Semaphore(0, int.MaxValue);
 
-            using (SocketCapture capture = new SocketCapture(captureEndPoint, listenerEndPoint))
+            var logger = new TestLogger("Throttle");
+
+            using (SocketCapture capture = new SocketCapture(captureEndPoint, listenerEndPoint, logger))
             using (DtlsConnectionListener listener = new DtlsConnectionListener(2, new IPEndPoint(IPAddress.Any, listenerEndPoint.Port), new TestLogger("Server")))
             using (DtlsUnityConnection connection = new DtlsUnityConnection(new TestLogger("Client "), captureEndPoint))
             {
@@ -333,24 +408,23 @@ IsdbLCwHYD3GVgk/D7NVxyU=
                 capture.SendToLocalSemaphore = listenerToConnectionThrottle;
                 Thread throttleThread = new Thread(() => {
                     // Trigger resend of HelloVerifyRequest
-                    Thread.Sleep(1000);
-                    listenerToConnectionThrottle.Release(1);
+                    capture.DiscardPacketForLocal();
 
-                    // ServerHello, Server Certificate
+                    capture.AssertPacketsToLocalCountEquals(1);
                     listenerToConnectionThrottle.Release(1);
 
                     // ServerHello, ServerCertificate
-                    
-                    listenerToConnectionThrottle.Release(1);
-
+                    // ServerCertificate
                     // ServerKeyExchange, ServerHelloDone
-                    listenerToConnectionThrottle.Release(1);
+                    capture.AssertPacketsToLocalCountEquals(3);
+                    listenerToConnectionThrottle.Release(3);
 
                     // Trigger a resend of ServerKeyExchange, ServerHelloDone
-                    Thread.Sleep(1000);
-                    listenerToConnectionThrottle.Release(1);
-
+                    capture.DiscardPacketForLocal();
+                    
+                    // From here, flush everything. We recover or not.
                     capture.SendToLocalSemaphore = null;
+                    listenerToConnectionThrottle.Release(1);
                 });
                 throttleThread.Start();
 
@@ -388,7 +462,7 @@ IsdbLCwHYD3GVgk/D7NVxyU=
         }
 
         [TestMethod]
-        public void TestResentHandshakeConnects()
+        public void TestResentServerHelloConnects()
         {
             IPEndPoint captureEndPoint = new IPEndPoint(IPAddress.Loopback, 27511);
             IPEndPoint listenerEndPoint = new IPEndPoint(IPAddress.Loopback, 27510);
@@ -407,23 +481,21 @@ IsdbLCwHYD3GVgk/D7NVxyU=
                 capture.SendToLocalSemaphore = listenerToConnectionThrottle;
                 Thread throttleThread = new Thread(() => {
                     // HelloVerifyRequest
+                    capture.AssertPacketsToLocalCountEquals(1);
                     listenerToConnectionThrottle.Release(1);
 
                     // ServerHello, Server Certificate
-                    listenerToConnectionThrottle.Release(1);
-
-                    // Trigger a resend of ServerHello, ServerCertificate
-                    Thread.Sleep(1000);
-                    listenerToConnectionThrottle.Release(1);
-
+                    // Server Certificate
                     // ServerKeyExchange, ServerHelloDone
-                    listenerToConnectionThrottle.Release(1);
+                    capture.AssertPacketsToLocalCountEquals(3);
+                    capture.DiscardPacketForLocal();
+                    listenerToConnectionThrottle.Release(2);
 
-                    // Trigger a resend of ServerKeyExchange, ServerHelloDone
-                    Thread.Sleep(1000);
-                    listenerToConnectionThrottle.Release(1);
+                    // Wait for the resends and recover
+                    capture.AssertPacketsToLocalCountEquals(3);
 
                     capture.SendToLocalSemaphore = null;
+                    listenerToConnectionThrottle.Release(3);
                 });
                 throttleThread.Start();
 

--- a/Hazel.UnitTests/TestHelper.cs
+++ b/Hazel.UnitTests/TestHelper.cs
@@ -196,12 +196,12 @@ namespace Hazel.UnitTests
             //Connect
             connection.Connect();
 
-            mutex.WaitOne();
+            Assert.IsTrue(mutex.WaitOne(100), "Timeout while connecting");
 
             connection.SendBytes(data, sendOption);
 
             //Wait until data is received
-            mutex2.WaitOne();
+            Assert.IsTrue(mutex2.WaitOne(100), "Timeout while sending data");
 
             Assert.AreEqual(data.Length, result.Value.Message.Length);
 

--- a/Hazel/Dtls/DtlsConnectionListener.cs
+++ b/Hazel/Dtls/DtlsConnectionListener.cs
@@ -159,7 +159,6 @@ namespace Hazel.Dtls
 
         // Private key component of certificate's public key
         private ByteSpan encodedCertificate;
-        private uint encodedCertificatesTotalSize;
         private RSA certificatePrivateKey;
 
         // HMAC key to validate ClientHello cookie
@@ -250,7 +249,6 @@ namespace Hazel.Dtls
 
             // Pre-fragment the certificate data
             this.encodedCertificate = Certificate.Encode(certificate);
-            this.encodedCertificatesTotalSize = (uint)encodedCertificate.Length;
         }
 
         /// <summary>
@@ -970,7 +968,7 @@ namespace Hazel.Dtls
 
             Handshake certificateHandshake = new Handshake();
             certificateHandshake.MessageType = HandshakeType.Certificate;
-            certificateHandshake.Length = this.encodedCertificatesTotalSize;
+            certificateHandshake.Length = (uint)certificateData.Length;
             certificateHandshake.MessageSequence = 2;
             certificateHandshake.FragmentOffset = 0;
             certificateHandshake.FragmentLength = (uint)certInitialFragmentSize;

--- a/Hazel/Dtls/DtlsUnityConnection.cs
+++ b/Hazel/Dtls/DtlsUnityConnection.cs
@@ -91,6 +91,8 @@ namespace Hazel.Dtls
             public Action AckCallback;
         }
 
+        internal byte HazelSessionVersion = HazelDtlsSessionInfo.CurrentClientSessionVersion;
+
         private readonly object syncRoot = new object();
         private readonly RandomNumberGenerator random = RandomNumberGenerator.Create();
 
@@ -929,6 +931,7 @@ namespace Hazel.Dtls
             ClientHello clientHello = new ClientHello();
             clientHello.Random = this.nextEpoch.ClientRandom;
             clientHello.Cookie = this.nextEpoch.Cookie;
+            clientHello.Session = new HazelDtlsSessionInfo(this.HazelSessionVersion);
             clientHello.CipherSuites = new byte[2];
             clientHello.CipherSuites.WriteBigEndian16((ushort)CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256);
             clientHello.SupportedCurves = new byte[2];

--- a/Hazel/Dtls/Handshake.cs
+++ b/Hazel/Dtls/Handshake.cs
@@ -589,6 +589,8 @@ namespace Hazel.Dtls
             + 1 // compression_method
             ;
 
+        public int Size => MinSize + Session.PayloadSize;
+
         /// <summary>
         /// Parse a Handshake ServerHello payload from wire format
         /// </summary>

--- a/Hazel/Dtls/Handshake.cs
+++ b/Hazel/Dtls/Handshake.cs
@@ -160,7 +160,7 @@ namespace Hazel.Dtls
         public const int MinSize = 0
             + 2 // client_version
             + Dtls.Random.Size // random
-            + 1 // session_id (size header included)
+            + 1 // session_id (size)
             + 1 // cookie (size)
             + 2 // cipher_suites (size)
             + 1 // compression_methods (size)
@@ -378,7 +378,6 @@ namespace Hazel.Dtls
             this.Random.CopyTo(span);
             span = span.Slice(Dtls.Random.Size);
 
-            // Do not encode session ids
             this.Session.Encode(span);
             span = span.Slice(this.Session.FullSize);
 

--- a/Hazel/Extensions.cs
+++ b/Hazel/Extensions.cs
@@ -4,6 +4,13 @@ namespace Hazel
 {
     public static class Extensions
     {
+        public static void Swap<T>(this IList<T> self, int idx0, int idx1)
+        {
+            var temp = self[idx0];
+            self[idx0] = self[idx1];
+            self[idx1] = temp;
+        }
+
         public static int ClampToInt(this float value, int min, int max)
         {
             int output = (int)value;


### PR DESCRIPTION
This allows us to pivot Certificate fragmentation setting and maintain backcompat with the older broken version.

It probably deviates us from some spec on setting up sessions, but from a pure DTLS perspective, the session bytes can be safely ignored. Since Hazel defines the underlying "connection protocol" and DTLS provides a "secured connection", this seems like an acceptable deviation.