### PR TITLE
Improve MaxCertFragmentSize calculation and test for fragmented cert packet reordering issues

### DIFF
--- a/Hazel.UnitTests/Dtls/DtlsConnectionTests.cs
+++ b/Hazel.UnitTests/Dtls/DtlsConnectionTests.cs
@@ -336,13 +336,13 @@ IsdbLCwHYD3GVgk/D7NVxyU=
                 capture.SendToLocalSemaphore = listenerToConnectionThrottle;
                 Thread throttleThread = new Thread(() => {
                     // HelloVerifyRequest
-                    capture.AssertPacketsToLocal(1);
+                    capture.AssertPacketsToLocalCountEquals(1);
                     listenerToConnectionThrottle.Release(1);
 
                     // ServerHello, Server Certificate (Fragment)
                     // Server Cert
                     // ServerKeyExchange, ServerHelloDone
-                    capture.AssertPacketsToLocal(3);
+                    capture.AssertPacketsToLocalCountEquals(3);
                     capture.ReorderPacketsForLocal(list => list.Swap(0, 1));
                     listenerToConnectionThrottle.Release(3);
 
@@ -410,13 +410,13 @@ IsdbLCwHYD3GVgk/D7NVxyU=
                     // Trigger resend of HelloVerifyRequest
                     capture.DiscardPacketForLocal();
 
-                    capture.AssertPacketsToLocal(1);
+                    capture.AssertPacketsToLocalCountEquals(1);
                     listenerToConnectionThrottle.Release(1);
 
                     // ServerHello, ServerCertificate
                     // ServerCertificate
                     // ServerKeyExchange, ServerHelloDone
-                    capture.AssertPacketsToLocal(3);
+                    capture.AssertPacketsToLocalCountEquals(3);
                     listenerToConnectionThrottle.Release(3);
 
                     // Trigger a resend of ServerKeyExchange, ServerHelloDone
@@ -481,18 +481,18 @@ IsdbLCwHYD3GVgk/D7NVxyU=
                 capture.SendToLocalSemaphore = listenerToConnectionThrottle;
                 Thread throttleThread = new Thread(() => {
                     // HelloVerifyRequest
-                    capture.AssertPacketsToLocal(1);
+                    capture.AssertPacketsToLocalCountEquals(1);
                     listenerToConnectionThrottle.Release(1);
 
                     // ServerHello, Server Certificate
                     // Server Certificate
                     // ServerKeyExchange, ServerHelloDone
-                    capture.AssertPacketsToLocal(3);
+                    capture.AssertPacketsToLocalCountEquals(3);
                     capture.DiscardPacketForLocal();
                     listenerToConnectionThrottle.Release(2);
 
                     // Wait for the resends and recover
-                    capture.AssertPacketsToLocal(3);
+                    capture.AssertPacketsToLocalCountEquals(3);
 
                     capture.SendToLocalSemaphore = null;
                     listenerToConnectionThrottle.Release(3);

--- a/Hazel.UnitTests/SocketCapture.cs
+++ b/Hazel.UnitTests/SocketCapture.cs
@@ -32,12 +32,12 @@ namespace Hazel.UnitTests
         private readonly BlockingCollection<ByteSpan> forRemote = new BlockingCollection<ByteSpan>();
 
         /// <summary>
-        /// Useful for debug logging, prefer <see cref="AssertPacketsToLocal(int)"/> for assertions
+        /// Useful for debug logging, prefer <see cref="AssertPacketsToLocalCountEquals(int)"/> for assertions
         /// </summary>
         public int PacketsForLocalCount => this.forLocal.Count;
 
         /// <summary>
-        /// Useful for debug logging, prefer <see cref="AssertPacketsToRemote(int)"/> for assertions
+        /// Useful for debug logging, prefer <see cref="AssertPacketsToRemoteCountEquals(int)"/> for assertions
         /// </summary>
         public int PacketsForRemoteCount => this.forRemote.Count;
 
@@ -180,7 +180,7 @@ namespace Hazel.UnitTests
             }
         }
 
-        public void AssertPacketsToLocal(int pktCnt)
+        public void AssertPacketsToLocalCountEquals(int pktCnt)
         {
             DateTime start = DateTime.UtcNow;
             while (this.forLocal.Count != pktCnt)
@@ -194,7 +194,7 @@ namespace Hazel.UnitTests
             }
         }
 
-        public void AssertPacketsToRemote(int pktCnt)
+        public void AssertPacketsToRemoteCountEquals(int pktCnt)
         {
             DateTime start = DateTime.UtcNow;
             while (this.forRemote.Count != pktCnt)

--- a/Hazel/Dtls/Handshake.cs
+++ b/Hazel/Dtls/Handshake.cs
@@ -589,6 +589,8 @@ namespace Hazel.Dtls
             + 1 // compression_method
             ;
 
+        public int Size => MinSize + Session.PayloadSize;
+
         /// <summary>
         /// Parse a Handshake ServerHello payload from wire format
         /// </summary>

--- a/Hazel/Extensions.cs
+++ b/Hazel/Extensions.cs
@@ -4,6 +4,13 @@ namespace Hazel
 {
     public static class Extensions
     {
+        public static void Swap<T>(this IList<T> self, int idx0, int idx1)
+        {
+            var temp = self[idx0];
+            self[idx0] = self[idx1];
+            self[idx1] = temp;
+        }
+
         public static int ClampToInt(this float value, int min, int max)
         {
             int output = (int)value;


### PR DESCRIPTION
Might need some extra thought on the tests. The problem is that the SocketCapture was grabbing a packet before waiting. Then it would implicitly discard that packet via wait time. If a packet is not in the queue, it's really hard to reorder the queue, so I made us wait, then grab a packet. I also wanted to make discarding packets explicit instead of timed, but packet arrival is very time-sensitive, so it's hard to assert that things are truly happening the way they should.