### PR TITLE
Convert Send to return type and misc cleanup

### DIFF
--- a/Hazel.UnitTests/StressTests.cs
+++ b/Hazel.UnitTests/StressTests.cs
@@ -24,7 +24,7 @@ namespace Hazel.UnitTests
                 new ParallelOptions { MaxDegreeOfParallelism = 64 },
                 (i) => {
                     
-                var connection = new UdpClientConnection(ep);
+                var connection = new UdpClientConnection(new TestLogger(), ep);
                 connection.KeepAliveInterval = 50;
 
                 connection.Connect(new byte[5]);

--- a/Hazel.UnitTests/TestHelper.cs
+++ b/Hazel.UnitTests/TestHelper.cs
@@ -20,18 +20,18 @@ namespace Hazel.UnitTests
         internal static void RunServerToClientTest(ThreadLimitedUdpConnectionListener listener, Connection connection, int dataSize, SendOption sendOption)
         {
             //Setup meta stuff 
-            byte[] data = BuildData(dataSize);
+            MessageWriter data = BuildData(sendOption, dataSize);
             ManualResetEvent mutex = new ManualResetEvent(false);
 
             //Setup listener
             listener.NewConnection += delegate (NewConnectionEventArgs ncArgs)
             {
-                ncArgs.Connection.SendBytes(data, sendOption);
+                ncArgs.Connection.Send(data);
             };
 
             listener.Start();
 
-            DataReceivedEventArgs? args = null;
+            DataReceivedEventArgs? result = null;
             //Setup conneciton
             connection.DataReceived += delegate (DataReceivedEventArgs a)
             {
@@ -39,7 +39,7 @@ namespace Hazel.UnitTests
 
                 try
                 {
-                    args = a;
+                    result = a;
                 }
                 finally
                 {
@@ -52,14 +52,14 @@ namespace Hazel.UnitTests
             //Wait until data is received
             mutex.WaitOne();
 
-            Assert.AreEqual(data.Length, args.Value.Message.Length);
-
+            var dataReader = ConvertToMessageReader(data);
+            Assert.AreEqual(dataReader.Length, result.Value.Message.Length);
             for (int i = 0; i < data.Length; i++)
             {
-                Assert.AreEqual(data[i], args.Value.Message.ReadByte());
+                Assert.AreEqual(dataReader.ReadByte(), result.Value.Message.ReadByte());
             }
 
-            Assert.AreEqual(sendOption, args.Value.SendOption);
+            Assert.AreEqual(sendOption, result.Value.SendOption);
         }
 
         /// <summary>
@@ -70,26 +70,26 @@ namespace Hazel.UnitTests
         internal static void RunServerToClientTest(NetworkConnectionListener listener, Connection connection, int dataSize, SendOption sendOption)
         {
             //Setup meta stuff 
-            byte[] data = BuildData(dataSize);
+            MessageWriter data = BuildData(sendOption, dataSize);
             ManualResetEvent mutex = new ManualResetEvent(false);
 
             //Setup listener
-            listener.NewConnection += delegate(NewConnectionEventArgs ncArgs)
+            listener.NewConnection += delegate (NewConnectionEventArgs ncArgs)
             {
-                ncArgs.Connection.SendBytes(data, sendOption);
+                ncArgs.Connection.Send(data);
             };
 
             listener.Start();
 
-            DataReceivedEventArgs? args = null;
+            DataReceivedEventArgs? result = null;
             //Setup conneciton
-            connection.DataReceived += delegate(DataReceivedEventArgs a)
+            connection.DataReceived += delegate (DataReceivedEventArgs a)
             {
                 Trace.WriteLine("Data was received correctly.");
 
                 try
                 {
-                    args = a;
+                    result = a;
                 }
                 finally
                 {
@@ -102,14 +102,14 @@ namespace Hazel.UnitTests
             //Wait until data is received
             mutex.WaitOne();
 
-            Assert.AreEqual(data.Length, args.Value.Message.Length);
-
+            var dataReader = ConvertToMessageReader(data);
+            Assert.AreEqual(dataReader.Length, result.Value.Message.Length);
             for (int i = 0; i < data.Length; i++)
             {
-                Assert.AreEqual(data[i], args.Value.Message.ReadByte());
+                Assert.AreEqual(dataReader.ReadByte(), result.Value.Message.ReadByte());
             }
 
-            Assert.AreEqual(sendOption, args.Value.SendOption);
+            Assert.AreEqual(sendOption, result.Value.SendOption);
         }
 
         /// <summary>
@@ -120,15 +120,15 @@ namespace Hazel.UnitTests
         internal static void RunClientToServerTest(NetworkConnectionListener listener, Connection connection, int dataSize, SendOption sendOption)
         {
             //Setup meta stuff 
-            byte[] data = BuildData(dataSize);
+            MessageWriter data = BuildData(sendOption, dataSize);
             ManualResetEvent mutex = new ManualResetEvent(false);
             ManualResetEvent mutex2 = new ManualResetEvent(false);
 
             //Setup listener
             DataReceivedEventArgs? result = null;
-            listener.NewConnection += delegate(NewConnectionEventArgs args)
+            listener.NewConnection += delegate (NewConnectionEventArgs args)
             {
-                args.Connection.DataReceived += delegate(DataReceivedEventArgs innerArgs)
+                args.Connection.DataReceived += delegate (DataReceivedEventArgs innerArgs)
                 {
                     Trace.WriteLine("Data was received correctly.");
 
@@ -147,16 +147,16 @@ namespace Hazel.UnitTests
 
             mutex.WaitOne();
 
-            connection.SendBytes(data, sendOption);
+            connection.Send(data);
 
             //Wait until data is received
             mutex2.WaitOne();
 
-            Assert.AreEqual(data.Length, result.Value.Message.Length);
-
+            var dataReader = ConvertToMessageReader(data);
+            Assert.AreEqual(dataReader.Length, result.Value.Message.Length);
             for (int i = 0; i < data.Length; i++)
             {
-                Assert.AreEqual(data[i], result.Value.Message.ReadByte());
+                Assert.AreEqual(dataReader.ReadByte(), result.Value.Message.ReadByte());
             }
 
             Assert.AreEqual(sendOption, result.Value.SendOption);
@@ -171,7 +171,7 @@ namespace Hazel.UnitTests
         internal static void RunClientToServerTest(ThreadLimitedUdpConnectionListener listener, Connection connection, int dataSize, SendOption sendOption)
         {
             //Setup meta stuff 
-            byte[] data = BuildData(dataSize);
+            MessageWriter data = BuildData(sendOption, dataSize);
             ManualResetEvent mutex = new ManualResetEvent(false);
             ManualResetEvent mutex2 = new ManualResetEvent(false);
 
@@ -198,16 +198,16 @@ namespace Hazel.UnitTests
 
             Assert.IsTrue(mutex.WaitOne(100), "Timeout while connecting");
 
-            connection.SendBytes(data, sendOption);
+            connection.Send(data);
 
             //Wait until data is received
             Assert.IsTrue(mutex2.WaitOne(100), "Timeout while sending data");
 
-            Assert.AreEqual(data.Length, result.Value.Message.Length);
-
+            var dataReader = ConvertToMessageReader(data);
+            Assert.AreEqual(dataReader.Length, result.Value.Message.Length);
             for (int i = 0; i < data.Length; i++)
             {
-                Assert.AreEqual(data[i], result.Value.Message.ReadByte());
+                Assert.AreEqual(dataReader.ReadByte(), result.Value.Message.ReadByte());
             }
 
             Assert.AreEqual(sendOption, result.Value.SendOption);
@@ -222,12 +222,12 @@ namespace Hazel.UnitTests
         {
             ManualResetEvent mutex = new ManualResetEvent(false);
 
-            connection.Disconnected += delegate(object sender, DisconnectedEventArgs args)
+            connection.Disconnected += delegate (object sender, DisconnectedEventArgs args)
             {
                 mutex.Set();
             };
 
-            listener.NewConnection += delegate(NewConnectionEventArgs args)
+            listener.NewConnection += delegate (NewConnectionEventArgs args)
             {
                 args.Connection.Disconnect("Testing");
             };
@@ -249,9 +249,9 @@ namespace Hazel.UnitTests
             ManualResetEvent mutex = new ManualResetEvent(false);
             ManualResetEvent mutex2 = new ManualResetEvent(false);
 
-            listener.NewConnection += delegate(NewConnectionEventArgs args)
+            listener.NewConnection += delegate (NewConnectionEventArgs args)
             {
-                args.Connection.Disconnected += delegate(object sender2, DisconnectedEventArgs args2)
+                args.Connection.Disconnected += delegate (object sender2, DisconnectedEventArgs args2)
                 {
                     mutex2.Set();
                 };
@@ -307,17 +307,31 @@ namespace Hazel.UnitTests
             }
         }
 
+        private static MessageReader ConvertToMessageReader(MessageWriter writer)
+        {
+            var output = new MessageReader();
+            output.Buffer = writer.Buffer;
+            output.Offset = writer.SendOption == SendOption.None ? 1 : 3;
+            output.Length = writer.Length - output.Offset;
+            output.Position = 0;
+
+            return output;
+        }
+
         /// <summary>
         ///     Builds new data of increaseing value bytes.
         /// </summary>
         /// <param name="dataSize">The number of bytes to generate.</param>
         /// <returns>The data.</returns>
-        static byte[] BuildData(int dataSize)
+        static MessageWriter BuildData(SendOption sendOption, int dataSize)
         {
-            byte[] data = new byte[dataSize];
+            var output = MessageWriter.Get(sendOption);
             for (int i = 0; i < dataSize; i++)
-                data[i] = (byte)i;
-            return data;
+            {
+                output.Write((byte)i);
+            }
+
+            return output;
         }
     }
 }

--- a/Hazel.UnitTests/TestHelper.cs
+++ b/Hazel.UnitTests/TestHelper.cs
@@ -54,7 +54,7 @@ namespace Hazel.UnitTests
 
             var dataReader = ConvertToMessageReader(data);
             Assert.AreEqual(dataReader.Length, result.Value.Message.Length);
-            for (int i = 0; i < data.Length; i++)
+            for (int i = 0; i < dataReader.Length; i++)
             {
                 Assert.AreEqual(dataReader.ReadByte(), result.Value.Message.ReadByte());
             }
@@ -104,7 +104,7 @@ namespace Hazel.UnitTests
 
             var dataReader = ConvertToMessageReader(data);
             Assert.AreEqual(dataReader.Length, result.Value.Message.Length);
-            for (int i = 0; i < data.Length; i++)
+            for (int i = 0; i < dataReader.Length; i++)
             {
                 Assert.AreEqual(dataReader.ReadByte(), result.Value.Message.ReadByte());
             }
@@ -205,7 +205,7 @@ namespace Hazel.UnitTests
 
             var dataReader = ConvertToMessageReader(data);
             Assert.AreEqual(dataReader.Length, result.Value.Message.Length);
-            for (int i = 0; i < data.Length; i++)
+            for (int i = 0; i < dataReader.Length; i++)
             {
                 Assert.AreEqual(dataReader.ReadByte(), result.Value.Message.ReadByte());
             }

--- a/Hazel.UnitTests/ThreadLimitedUdpConnectionTests.cs
+++ b/Hazel.UnitTests/ThreadLimitedUdpConnectionTests.cs
@@ -20,7 +20,7 @@ namespace Hazel.UnitTests
 
         protected UdpConnection CreateConnection(IPEndPoint endPoint, ILogger logger, IPMode ipMode = IPMode.IPv4)
         {
-            return new UdpClientConnection(endPoint, ipMode);
+            return new UdpClientConnection(logger, endPoint, ipMode);
         }
 
         [TestMethod]

--- a/Hazel.UnitTests/UdpConnectionTestHarness.cs
+++ b/Hazel.UnitTests/UdpConnectionTestHarness.cs
@@ -10,6 +10,11 @@ namespace Hazel.UnitTests
     internal class UdpConnectionTestHarness : UdpConnection
     {
         public List<MessageReader> BytesSent = new List<MessageReader>();
+
+        public UdpConnectionTestHarness() : base(new TestLogger())
+        {
+        }
+
         public ushort ReliableReceiveLast => this.reliableReceiveLast;
 
 

--- a/Hazel.UnitTests/UdpConnectionTests.cs
+++ b/Hazel.UnitTests/UdpConnectionTests.cs
@@ -21,7 +21,7 @@ namespace Hazel.UnitTests
             bool clientDisconnected = false;
 
             using (UdpConnectionListener listener = new UdpConnectionListener(new IPEndPoint(IPAddress.Any, 4296)))
-            using (UdpConnection connection = new UdpClientConnection(ep))
+            using (UdpConnection connection = new UdpClientConnection(new TestLogger("Client"), ep))
             {
                 listener.NewConnection += (evt) =>
                 {
@@ -53,7 +53,7 @@ namespace Hazel.UnitTests
             bool clientDisconnected = false;
 
             using (UdpConnectionListener listener = new UdpConnectionListener(new IPEndPoint(IPAddress.Any, 4296)))
-            using (UdpConnection connection = new UdpClientConnection(ep))
+            using (UdpConnection connection = new UdpClientConnection(new TestLogger("Client"), ep))
             {
                 listener.NewConnection += (evt) =>
                 {
@@ -86,7 +86,7 @@ namespace Hazel.UnitTests
             IPEndPoint ep = new IPEndPoint(IPAddress.Loopback, 4296);
 
             using (UdpConnectionListener listener = new UdpConnectionListener(new IPEndPoint(IPAddress.Any, 4296)))
-            using (UdpConnection connection = new UdpClientConnection(ep))
+            using (UdpConnection connection = new UdpClientConnection(new TestLogger("Client"), ep))
             {
                 listener.Start();
 
@@ -107,7 +107,7 @@ namespace Hazel.UnitTests
         {
             byte[] TestData = new byte[] { 1, 2, 3, 4, 5, 6 };
             using (UdpConnectionListener listener = new UdpConnectionListener(new IPEndPoint(IPAddress.Any, 4296)))
-            using (UdpConnection connection = new UdpClientConnection(new IPEndPoint(IPAddress.Loopback, 4296)))
+            using (UdpConnection connection = new UdpClientConnection(new TestLogger("Client"), new IPEndPoint(IPAddress.Loopback, 4296)))
             {
                 listener.Start();
 
@@ -132,7 +132,7 @@ namespace Hazel.UnitTests
         {
             byte[] TestData = new byte[] { 1, 2, 3, 4, 5, 6 };
             using (UdpConnectionListener listener = new UdpConnectionListener(new IPEndPoint(IPAddress.Any, 4296)))
-            using (UdpConnection connection = new UdpClientConnection(new IPEndPoint(IPAddress.Loopback, 4296)))
+            using (UdpConnection connection = new UdpClientConnection(new TestLogger("Client"), new IPEndPoint(IPAddress.Loopback, 4296)))
             {
                 MessageReader output = null;
                 listener.NewConnection += delegate (NewConnectionEventArgs e)
@@ -169,7 +169,7 @@ namespace Hazel.UnitTests
         public void UdpIPv4ConnectionTest()
         {
             using (UdpConnectionListener listener = new UdpConnectionListener(new IPEndPoint(IPAddress.Any, 4296)))
-            using (UdpConnection connection = new UdpClientConnection(new IPEndPoint(IPAddress.Loopback, 4296)))
+            using (UdpConnection connection = new UdpClientConnection(new TestLogger("Client"), new IPEndPoint(IPAddress.Loopback, 4296)))
             {
                 listener.Start();
 
@@ -192,13 +192,13 @@ namespace Hazel.UnitTests
                     Console.WriteLine("v6 connection: " + ((NetworkConnection)evt.Connection).GetIP4Address());
                 };
 
-                using (UdpConnection connection = new UdpClientConnection(new IPEndPoint(IPAddress.Parse("127.0.0.1"), 4296)))
+                using (UdpConnection connection = new UdpClientConnection(new TestLogger("Client"), new IPEndPoint(IPAddress.Parse("127.0.0.1"), 4296)))
                 {
                     connection.Connect();
                     Assert.AreEqual(ConnectionState.Connected, connection.State);
                 }
 
-                using (UdpConnection connection = new UdpClientConnection(new IPEndPoint(IPAddress.IPv6Loopback, 4296), IPMode.IPv6))
+                using (UdpConnection connection = new UdpClientConnection(new TestLogger("Client"), new IPEndPoint(IPAddress.IPv6Loopback, 4296), IPMode.IPv6))
                 {
                     connection.Connect();
                     Assert.AreEqual(ConnectionState.Connected, connection.State);
@@ -278,7 +278,7 @@ namespace Hazel.UnitTests
             {
                 listener.Start();
 
-                using (UdpConnection connection = new UdpClientConnection(new IPEndPoint(IPAddress.Parse("127.0.0.1"), 4296), IPMode.IPv6))
+                using (UdpConnection connection = new UdpClientConnection(new TestLogger("Client"), new IPEndPoint(IPAddress.Parse("127.0.0.1"), 4296), IPMode.IPv6))
                 {
                     connection.Connect();
                 }
@@ -292,7 +292,7 @@ namespace Hazel.UnitTests
         public void UdpUnreliableServerToClientTest()
         {
             using (UdpConnectionListener listener = new UdpConnectionListener(new IPEndPoint(IPAddress.Any, 4296)))
-            using (UdpConnection connection = new UdpClientConnection(new IPEndPoint(IPAddress.Loopback, 4296)))
+            using (UdpConnection connection = new UdpClientConnection(new TestLogger("Client"), new IPEndPoint(IPAddress.Loopback, 4296)))
             {
                 TestHelper.RunServerToClientTest(listener, connection, 10, SendOption.None);
             }
@@ -305,7 +305,7 @@ namespace Hazel.UnitTests
         public void UdpReliableServerToClientTest()
         {
             using (UdpConnectionListener listener = new UdpConnectionListener(new IPEndPoint(IPAddress.Any, 4296)))
-            using (UdpConnection connection = new UdpClientConnection(new IPEndPoint(IPAddress.Loopback, 4296)))
+            using (UdpConnection connection = new UdpClientConnection(new TestLogger("Client"), new IPEndPoint(IPAddress.Loopback, 4296)))
             {
                 TestHelper.RunServerToClientTest(listener, connection, 10, SendOption.Reliable);
             }
@@ -318,7 +318,7 @@ namespace Hazel.UnitTests
         public void UdpUnreliableClientToServerTest()
         {
             using (UdpConnectionListener listener = new UdpConnectionListener(new IPEndPoint(IPAddress.Any, 4296)))
-            using (UdpConnection connection = new UdpClientConnection(new IPEndPoint(IPAddress.Loopback, 4296)))
+            using (UdpConnection connection = new UdpClientConnection(new TestLogger("Client"), new IPEndPoint(IPAddress.Loopback, 4296)))
             {
                 TestHelper.RunClientToServerTest(listener, connection, 10, SendOption.None);
             }
@@ -331,7 +331,7 @@ namespace Hazel.UnitTests
         public void UdpReliableClientToServerTest()
         {
             using (UdpConnectionListener listener = new UdpConnectionListener(new IPEndPoint(IPAddress.Any, 4296)))
-            using (UdpConnection connection = new UdpClientConnection(new IPEndPoint(IPAddress.Loopback, 4296)))
+            using (UdpConnection connection = new UdpClientConnection(new TestLogger("Client"), new IPEndPoint(IPAddress.Loopback, 4296)))
             {
                 TestHelper.RunClientToServerTest(listener, connection, 10, SendOption.Reliable);
             }
@@ -345,7 +345,7 @@ namespace Hazel.UnitTests
         {
 #if DEBUG
             using (UdpConnectionListener listener = new UdpConnectionListener(new IPEndPoint(IPAddress.Any, 4296)))
-            using (UdpConnection connection = new UdpClientConnection(new IPEndPoint(IPAddress.Loopback, 4296)))
+            using (UdpConnection connection = new UdpClientConnection(new TestLogger("Client"), new IPEndPoint(IPAddress.Loopback, 4296)))
             {
                 listener.Start();
 
@@ -374,7 +374,7 @@ namespace Hazel.UnitTests
         public void KeepAliveClientTest()
         {
             using (UdpConnectionListener listener = new UdpConnectionListener(new IPEndPoint(IPAddress.Any, 4296)))
-            using (UdpConnection connection = new UdpClientConnection(new IPEndPoint(IPAddress.Loopback, 4296)))
+            using (UdpConnection connection = new UdpClientConnection(new TestLogger("Client"), new IPEndPoint(IPAddress.Loopback, 4296)))
             {
                 listener.Start();
 
@@ -401,7 +401,7 @@ namespace Hazel.UnitTests
             ManualResetEvent mutex = new ManualResetEvent(false);
 
             using (UdpConnectionListener listener = new UdpConnectionListener(new IPEndPoint(IPAddress.Any, 4296)))
-            using (UdpConnection connection = new UdpClientConnection(new IPEndPoint(IPAddress.Loopback, 4296)))
+            using (UdpConnection connection = new UdpClientConnection(new TestLogger("Client"), new IPEndPoint(IPAddress.Loopback, 4296)))
             {
                 UdpConnection client = null;
                 listener.NewConnection += delegate (NewConnectionEventArgs args)
@@ -437,7 +437,7 @@ namespace Hazel.UnitTests
         public void ClientDisconnectTest()
         {
             using (UdpConnectionListener listener = new UdpConnectionListener(new IPEndPoint(IPAddress.Any, 4296)))
-            using (UdpConnection connection = new UdpClientConnection(new IPEndPoint(IPAddress.Loopback, 4296)))
+            using (UdpConnection connection = new UdpClientConnection(new TestLogger("Client"), new IPEndPoint(IPAddress.Loopback, 4296)))
             {
                 TestHelper.RunClientDisconnectTest(listener, connection);
             }
@@ -449,7 +449,7 @@ namespace Hazel.UnitTests
         public void ClientDisconnectOnDisposeTest()
         {
             using (UdpConnectionListener listener = new UdpConnectionListener(new IPEndPoint(IPAddress.Any, 4296)))
-            using (UdpConnection connection = new UdpClientConnection(new IPEndPoint(IPAddress.Loopback, 4296)))
+            using (UdpConnection connection = new UdpClientConnection(new TestLogger("Client"), new IPEndPoint(IPAddress.Loopback, 4296)))
             {
                 TestHelper.RunClientDisconnectOnDisposeTest(listener, connection);
             }
@@ -462,7 +462,7 @@ namespace Hazel.UnitTests
         public void ServerDisconnectTest()
         {
             using (UdpConnectionListener listener = new UdpConnectionListener(new IPEndPoint(IPAddress.Any, 4296)))
-            using (UdpConnection connection = new UdpClientConnection(new IPEndPoint(IPAddress.Loopback, 4296)))
+            using (UdpConnection connection = new UdpClientConnection(new TestLogger("Client"), new IPEndPoint(IPAddress.Loopback, 4296)))
             {
                 TestHelper.RunServerDisconnectTest(listener, connection);
             }
@@ -475,7 +475,7 @@ namespace Hazel.UnitTests
         public void ServerExtraDataDisconnectTest()
         {
             using (UdpConnectionListener listener = new UdpConnectionListener(new IPEndPoint(IPAddress.Any, 4296)))
-            using (UdpConnection connection = new UdpClientConnection(new IPEndPoint(IPAddress.Loopback, 4296)))
+            using (UdpConnection connection = new UdpClientConnection(new TestLogger("Client"), new IPEndPoint(IPAddress.Loopback, 4296)))
             {
                 string received = null;
                 ManualResetEvent mutex = new ManualResetEvent(false);

--- a/Hazel/Connection.cs
+++ b/Hazel/Connection.cs
@@ -131,7 +131,7 @@ namespace Hazel
         ///     Sends a number of bytes to the end point of the connection using the specified <see cref="SendOption"/>.
         /// </summary>
         /// <param name="msg">The message to send.</param>
-        public abstract SendError Send(MessageWriter msg);
+        public abstract SendErrors Send(MessageWriter msg);
                 
         /// <summary>
         ///     Connects the connection to a server and begins listening.

--- a/Hazel/Connection.cs
+++ b/Hazel/Connection.cs
@@ -140,22 +140,7 @@ namespace Hazel
         ///     </para>
         /// </remarks>
         public abstract void Send(MessageWriter msg);
-
-        /// <summary>
-        ///     Sends a number of bytes to the end point of the connection using the specified <see cref="SendOption"/>.
-        /// </summary>
-        /// <param name="bytes">The bytes of the message to send.</param>
-        /// <param name="sendOption">The option specifying how the message should be sent.</param>
-        /// <remarks>
-        ///     <include file="DocInclude/common.xml" path="docs/item[@name='Connection_SendBytes_General']/*" />
-        ///     <para>
-        ///         The sendOptions parameter is only a request to use those options and the actual method used to send the
-        ///         data is up to the implementation. There are circumstances where this parameter may be ignored but in 
-        ///         general any implementer should aim to always follow the user's request.
-        ///     </para>
-        /// </remarks>
-        public abstract void SendBytes(byte[] bytes, SendOption sendOption = SendOption.None);
-        
+                
         /// <summary>
         ///     Connects the connection to a server and begins listening.
         ///     This method blocks and may thrown if there is a problem connecting.

--- a/Hazel/Connection.cs
+++ b/Hazel/Connection.cs
@@ -131,15 +131,7 @@ namespace Hazel
         ///     Sends a number of bytes to the end point of the connection using the specified <see cref="SendOption"/>.
         /// </summary>
         /// <param name="msg">The message to send.</param>
-        /// <remarks>
-        ///     <include file="DocInclude/common.xml" path="docs/item[@name='Connection_SendBytes_General']/*" />
-        ///     <para>
-        ///         The sendOptions parameter is only a request to use those options and the actual method used to send the
-        ///         data is up to the implementation. There are circumstances where this parameter may be ignored but in 
-        ///         general any implementer should aim to always follow the user's request.
-        ///     </para>
-        /// </remarks>
-        public abstract void Send(MessageWriter msg);
+        public abstract SendError Send(MessageWriter msg);
                 
         /// <summary>
         ///     Connects the connection to a server and begins listening.

--- a/Hazel/FewerThreads/ThreadLimitedUdpConnectionListener.cs
+++ b/Hazel/FewerThreads/ThreadLimitedUdpConnectionListener.cs
@@ -290,7 +290,7 @@ namespace Hazel.Udp.FewerThreads
 
                         if (AcceptConnection != null)
                         {
-                            if (!AcceptConnection((IPEndPoint)remoteEndPoint, message.Buffer, out var response))
+                            if (!AcceptConnection(remoteEndPoint, message.Buffer, out var response))
                             {
                                 message.Recycle();
                                 if (response != null)
@@ -303,7 +303,7 @@ namespace Hazel.Udp.FewerThreads
                         }
 
                         aware = false;
-                        connection = new ThreadLimitedUdpServerConnection(this, connectionId, (IPEndPoint)remoteEndPoint, this.IPMode);
+                        connection = new ThreadLimitedUdpServerConnection(this, connectionId, remoteEndPoint, this.IPMode, this.Logger);
                         if (!this.allConnections.TryAdd(connectionId, connection))
                         {
                             throw new HazelException("Failed to add a connection. This should never happen.");

--- a/Hazel/FewerThreads/ThreadLimitedUdpServerConnection.cs
+++ b/Hazel/FewerThreads/ThreadLimitedUdpServerConnection.cs
@@ -28,8 +28,8 @@ namespace Hazel.Udp.FewerThreads
         /// <param name="listener">The listener that created this connection.</param>
         /// <param name="endPoint">The endpoint that we are connected to.</param>
         /// <param name="IPMode">The IPMode we are connected using.</param>
-        internal ThreadLimitedUdpServerConnection(ThreadLimitedUdpConnectionListener listener, ThreadLimitedUdpConnectionListener.ConnectionId connectionId, IPEndPoint endPoint, IPMode IPMode)
-            : base()
+        internal ThreadLimitedUdpServerConnection(ThreadLimitedUdpConnectionListener listener, ThreadLimitedUdpConnectionListener.ConnectionId connectionId, IPEndPoint endPoint, IPMode IPMode, ILogger logger)
+            : base(logger)
         {
             this.Listener = listener;
             this.ConnectionId = connectionId;

--- a/Hazel/SendError.cs
+++ b/Hazel/SendError.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Hazel
+{
+    [Flags]
+    public enum SendError
+    {
+        None,
+        Disconnected,
+    }
+}

--- a/Hazel/SendError.cs
+++ b/Hazel/SendError.cs
@@ -10,5 +10,6 @@ namespace Hazel
     {
         None,
         Disconnected,
+        Unknown
     }
 }

--- a/Hazel/SendErrors.cs
+++ b/Hazel/SendErrors.cs
@@ -6,7 +6,7 @@ using System.Text;
 namespace Hazel
 {
     [Flags]
-    public enum SendError
+    public enum SendErrors
     {
         None,
         Disconnected,

--- a/Hazel/Udp/UdpClientConnection.cs
+++ b/Hazel/Udp/UdpClientConnection.cs
@@ -33,8 +33,8 @@ namespace Hazel.Udp
         ///     Creates a new UdpClientConnection.
         /// </summary>
         /// <param name="remoteEndPoint">A <see cref="NetworkEndPoint"/> to connect to.</param>
-        public UdpClientConnection(IPEndPoint remoteEndPoint, IPMode ipMode = IPMode.IPv4)
-            : base()
+        public UdpClientConnection(ILogger logger, IPEndPoint remoteEndPoint, IPMode ipMode = IPMode.IPv4)
+            : base(logger)
         {
             this.EndPoint = remoteEndPoint;
             this.IPMode = ipMode;

--- a/Hazel/Udp/UdpConnection.cs
+++ b/Hazel/Udp/UdpConnection.cs
@@ -83,21 +83,6 @@ namespace Hazel.Udp
                     break;
             }
         }
-
-        /// <inheritdoc/>
-        /// <remarks>
-        ///     <include file="DocInclude/common.xml" path="docs/item[@name='Connection_SendBytes_General']/*" />
-        ///     <para>
-        ///         Udp connections can currently send messages using <see cref="SendOption.None"/> and
-        ///         <see cref="SendOption.Reliable"/>. Fragmented messages are not currently supported and will default to
-        ///         <see cref="SendOption.None"/> until implemented.
-        ///     </para>
-        /// </remarks>
-        public override void SendBytes(byte[] bytes, SendOption sendOption = SendOption.None)
-        {
-            //Add header information and send
-            HandleSend(bytes, (byte)sendOption);
-        }
         
         /// <summary>
         ///     Handles the reliable/fragmented sending from this connection.

--- a/Hazel/Udp/UdpConnection.cs
+++ b/Hazel/Udp/UdpConnection.cs
@@ -59,10 +59,12 @@ namespace Hazel.Udp
         protected abstract void WriteBytesToConnection(byte[] bytes, int length);
 
         /// <inheritdoc/>
-        public override void Send(MessageWriter msg)
+        public override SendError Send(MessageWriter msg)
         {
             if (this._state != ConnectionState.Connected)
-                throw new InvalidOperationException("Could not send data as this Connection is not connected. Did you disconnect?");
+            {
+                return SendError.Disconnected;
+            }
 
             byte[] buffer = new byte[msg.Length];
             Buffer.BlockCopy(msg.Buffer, 0, buffer, 0, msg.Length);
@@ -82,6 +84,8 @@ namespace Hazel.Udp
                     Statistics.LogUnreliableSend(buffer.Length - 1);
                     break;
             }
+
+            return SendError.None;
         }
         
         /// <summary>

--- a/Hazel/Udp/UdpConnection.cs
+++ b/Hazel/Udp/UdpConnection.cs
@@ -61,11 +61,11 @@ namespace Hazel.Udp
         protected abstract void WriteBytesToConnection(byte[] bytes, int length);
 
         /// <inheritdoc/>
-        public override SendError Send(MessageWriter msg)
+        public override SendErrors Send(MessageWriter msg)
         {
             if (this._state != ConnectionState.Connected)
             {
-                return SendError.Disconnected;
+                return SendErrors.Disconnected;
             }
 
             try
@@ -92,10 +92,10 @@ namespace Hazel.Udp
             catch (Exception e)
             {
                 this.logger?.WriteError("Unknown exception while sending: " + e);
-                return SendError.Unknown;
+                return SendErrors.Unknown;
             }
 
-            return SendError.None;
+            return SendErrors.None;
         }
         
         /// <summary>

--- a/Hazel/Udp/UdpConnectionListener.cs
+++ b/Hazel/Udp/UdpConnectionListener.cs
@@ -204,7 +204,7 @@ namespace Hazel.Udp
                         }
 
                         aware = false;
-                        connection = new UdpServerConnection(this, (IPEndPoint)remoteEndPoint, this.IPMode);
+                        connection = new UdpServerConnection(this, (IPEndPoint)remoteEndPoint, this.IPMode, this.Logger);
                         if (!this.allConnections.TryAdd(remoteEndPoint, connection))
                         {
                             throw new HazelException("Failed to add a connection. This should never happen.");

--- a/Hazel/Udp/UdpConnectionListener.cs
+++ b/Hazel/Udp/UdpConnectionListener.cs
@@ -24,7 +24,7 @@ namespace Hazel.Udp
         public delegate bool AcceptConnectionCheck(IPEndPoint endPoint, byte[] input, out byte[] response);
 
         private Socket socket;
-        private Action<string> Logger;
+        private ILogger Logger;
         private Timer reliablePacketTimer;
 
         private ConcurrentDictionary<EndPoint, UdpServerConnection> allConnections = new ConcurrentDictionary<EndPoint, UdpServerConnection>();
@@ -35,7 +35,7 @@ namespace Hazel.Udp
         ///     Creates a new UdpConnectionListener for the given <see cref="IPAddress"/>, port and <see cref="IPMode"/>.
         /// </summary>
         /// <param name="endPoint">The endpoint to listen on.</param>
-        public UdpConnectionListener(IPEndPoint endPoint, IPMode ipMode = IPMode.IPv4, Action<string> logger = null)
+        public UdpConnectionListener(IPEndPoint endPoint, IPMode ipMode = IPMode.IPv4, ILogger logger = null)
         {
             this.Logger = logger;
             this.EndPoint = endPoint;
@@ -101,7 +101,7 @@ namespace Hazel.Udp
             {
                 message?.Recycle();
 
-                this.Logger?.Invoke("Socket Ex in StartListening: " + sx.Message);
+                this.Logger?.WriteError("Socket Ex in StartListening: " + sx.Message);
 
                 Thread.Sleep(10);
                 StartListeningForData();
@@ -110,7 +110,7 @@ namespace Hazel.Udp
             catch (Exception ex)
             {
                 message.Recycle();
-                this.Logger?.Invoke("Stopped due to: " + ex.Message);
+                this.Logger?.WriteError("Stopped due to: " + ex.Message);
                 return;
             }
         }
@@ -142,7 +142,7 @@ namespace Hazel.Udp
                 // This thread suggests the IP is not passed out from WinSoc so maybe not possible
                 // http://stackoverflow.com/questions/2576926/python-socket-error-on-udp-data-receive-10054
                 message.Recycle();
-                this.Logger?.Invoke($"Socket Ex {sx.SocketErrorCode} in ReadCallback: {sx.Message}");
+                this.Logger?.WriteError($"Socket Ex {sx.SocketErrorCode} in ReadCallback: {sx.Message}");
 
                 Thread.Sleep(10);
                 StartListeningForData();
@@ -152,7 +152,7 @@ namespace Hazel.Udp
             {
                 //If the socket's been disposed then we can just end there.
                 message.Recycle();
-                this.Logger?.Invoke("Stopped due to: " + ex.Message);
+                this.Logger?.WriteError("Stopped due to: " + ex.Message);
                 return;
             }
 
@@ -161,7 +161,7 @@ namespace Hazel.Udp
             if (bytesReceived == 0)
             {
                 message.Recycle();
-                this.Logger?.Invoke("Received 0 bytes");
+                this.Logger?.WriteInfo("Received 0 bytes");
                 Thread.Sleep(10);
                 StartListeningForData();
                 return;
@@ -266,7 +266,7 @@ namespace Hazel.Udp
             }
             catch (SocketException e)
             {
-                this.Logger?.Invoke("Could not send data as a SocketException occurred: " + e);
+                this.Logger?.WriteError("Could not send data as a SocketException occurred: " + e);
             }
             catch (ObjectDisposedException)
             {

--- a/Hazel/Udp/UdpServerConnection.cs
+++ b/Hazel/Udp/UdpServerConnection.cs
@@ -24,8 +24,8 @@ namespace Hazel.Udp
         /// <param name="listener">The listener that created this connection.</param>
         /// <param name="endPoint">The endpoint that we are connected to.</param>
         /// <param name="IPMode">The IPMode we are connected using.</param>
-        internal UdpServerConnection(UdpConnectionListener listener, IPEndPoint endPoint, IPMode IPMode)
-            : base()
+        internal UdpServerConnection(UdpConnectionListener listener, IPEndPoint endPoint, IPMode IPMode, ILogger logger)
+            : base(logger)
         {
             this.Listener = listener;
             this.EndPoint = endPoint;

--- a/Hazel/Udp/UnityUdpClientConnection.cs
+++ b/Hazel/Udp/UnityUdpClientConnection.cs
@@ -13,12 +13,10 @@ namespace Hazel.Udp
     public class UnityUdpClientConnection : UdpConnection
     {
         private Socket socket;
-        protected readonly ILogger logger;
 
         public UnityUdpClientConnection(ILogger logger, IPEndPoint remoteEndPoint, IPMode ipMode = IPMode.IPv4)
-            : base()
+            : base(logger)
         {
-            this.logger = logger;
             this.EndPoint = remoteEndPoint;
             this.IPMode = ipMode;
 


### PR DESCRIPTION
It's been an obnoxious feature that Send throws when not connection. In my experience, the common pattern is just to silently ignore throws from send. But occasionally, senders will want to clean up connection state or similar, so I gave Send a return type.

While doing this, I pushed ILogger into the Unity*Listener and *Connection classes and deleted SendBytes which really no one should be using since it's less efficient than Send.