### PR TITLE
Adding warning level to logging and changing duplicate record errors to warnings

### DIFF
--- a/Hazel.UnitTests/TestLogger.cs
+++ b/Hazel.UnitTests/TestLogger.cs
@@ -27,6 +27,18 @@ namespace Hazel.UnitTests
             }
         }
 
+        public void WriteWarning(string msg)
+        {
+            if (string.IsNullOrEmpty(this.prefix))
+            {
+                Console.WriteLine($"[WARN] {msg}");
+            }
+            else
+            {
+                Console.WriteLine($"[{this.prefix}][WARN] {msg}");
+            }
+        }
+
         public void WriteError(string msg)
         {
             if (string.IsNullOrEmpty(this.prefix))

--- a/Hazel.UnitTests/UPnPTests.cs
+++ b/Hazel.UnitTests/UPnPTests.cs
@@ -36,6 +36,11 @@ namespace Hazel.UnitTests
             Console.WriteLine(msg);
         }
 
+        public void WriteWarning(string msg)
+        {
+            Console.WriteLine(msg);
+        }
+
         public void WriteError(string msg)
         {
             Console.WriteLine(msg);

--- a/Hazel/Dtls/DtlsUnityConnection.cs
+++ b/Hazel/Dtls/DtlsUnityConnection.cs
@@ -437,7 +437,7 @@ namespace Hazel.Dtls
 
                     if ((this.currentEpoch.PreviousSequenceWindowBitmask & windowMask) != 0)
                     {
-                        this.logger.WriteError("Dropping duplicate record");
+                        this.logger.WriteWarning("Dropping duplicate record");
                         continue;
                     }
                 }
@@ -617,7 +617,7 @@ namespace Hazel.Dtls
                         if (this.nextEpoch.Cookie.Length == helloVerifyRequest.Cookie.Length
                             && Const.ConstantCompareSpans(this.nextEpoch.Cookie, helloVerifyRequest.Cookie) == 1)
                         {
-                            this.logger.WriteError("Dropping duplicate HelloVerifyRequest handshake message");
+                            this.logger.WriteWarning("Dropping duplicate HelloVerifyRequest handshake message");
                             continue;
                         }
 

--- a/Hazel/UPnP/ILogger.cs
+++ b/Hazel/UPnP/ILogger.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Hazel
 {
@@ -10,6 +6,7 @@ namespace Hazel
     {
         void WriteVerbose(string msg);
         void WriteError(string msg);
+        void WriteWarning(string msg);
         void WriteInfo(string msg);
     }
 
@@ -22,6 +19,10 @@ namespace Hazel
         }
 
         public void WriteError(string msg)
+        {
+        }
+
+        public void WriteWarning(string msg)
         {
         }
 
@@ -44,6 +45,11 @@ namespace Hazel
             {
                 Console.WriteLine($"{DateTime.Now} [VERBOSE] {msg}");
             }
+        }
+
+        public void WriteWarning(string msg)
+        {
+            Console.WriteLine($"{DateTime.Now} [WARN] {msg}");
         }
 
         public void WriteError(string msg)


### PR DESCRIPTION
The duplicate records are pretty much normal/expected, but could be indicative or supporting evidence for a network issue - turning to a warning for now