### PR TITLE
Reduce send locking and add parallel-pipelining

### DIFF
--- a/Hazel/Dtls/DtlsConnectionListener.cs
+++ b/Hazel/Dtls/DtlsConnectionListener.cs
@@ -22,143 +22,6 @@ namespace Hazel.Dtls
         // Min MTU - UDP+IP header - 1 (for good measure. :))
         private const int MaxCertFragmentSizeV1 = 576 - 32 - 1;
 
-        /// <summary>
-        /// Current state of handshake sequence
-        /// </summary>
-        enum HandshakeState
-        {
-            ExpectingHello,
-            ExpectingClientKeyExchange,
-            ExpectingChangeCipherSpec,
-            ExpectingFinish
-        }
-
-        /// <summary>
-        /// State to manage the current epoch `N`
-        /// </summary>
-        struct CurrentEpoch
-        {
-            public ulong NextOutgoingSequence;
-
-            public ulong NextExpectedSequence;
-            public ulong PreviousSequenceWindowBitmask;
-
-            public IRecordProtection RecordProtection;
-            public IRecordProtection PreviousRecordProtection;
-
-            // Need to keep these around so we can re-transmit our
-            // last handshake record flight
-            public ByteSpan ExpectedClientFinishedVerification;
-            public ByteSpan ServerFinishedVerification;
-            public ulong NextOutgoingSequenceForPreviousEpoch;
-        }
-
-        /// <summary>
-        /// State to manage the transition from the current
-        /// epoch `N` to epoch `N+1`
-        /// </summary>
-        struct NextEpoch
-        {
-            public ushort Epoch;
-
-            public HandshakeState State;
-            public CipherSuite SelectedCipherSuite;
-
-            public ulong NextOutgoingSequence;
-
-            public IHandshakeCipherSuite Handshake;
-            public IRecordProtection RecordProtection;
-
-            public ByteSpan ClientRandom;
-            public ByteSpan ServerRandom;
-
-            public Sha256Stream VerificationStream;
-
-            public ByteSpan ClientVerification;
-            public ByteSpan ServerVerification;
-
-        }
-
-        /// <summary>
-        /// Per-peer state
-        /// </summary>
-        sealed class PeerData : IDisposable
-        {
-            public ushort Epoch;
-            public bool CanHandleApplicationData;
-
-            public HazelDtlsSessionInfo Session;
-
-            public CurrentEpoch CurrentEpoch;
-            public NextEpoch  NextEpoch;
-
-            public ConnectionId ConnectionId;
-
-            public readonly List<ByteSpan> QueuedApplicationDataMessage = new List<ByteSpan>();
-            public readonly ConcurrentBag<MessageReader> ApplicationData = new ConcurrentBag<MessageReader>();
-            public readonly ProtocolVersion ProtocolVersion;
-
-            public DateTime StartOfNegotiation;
-
-            public PeerData(ConnectionId connectionId, ulong nextExpectedSequenceNumber, ProtocolVersion protocolVersion)
-            {
-                ByteSpan block = new byte[2 * Finished.Size];
-                this.CurrentEpoch.ServerFinishedVerification = block.Slice(0, Finished.Size);
-                this.CurrentEpoch.ExpectedClientFinishedVerification = block.Slice(Finished.Size, Finished.Size);
-                this.ProtocolVersion = protocolVersion;
-
-                ResetPeer(connectionId, nextExpectedSequenceNumber);
-            }
-
-            public void ResetPeer(ConnectionId connectionId, ulong nextExpectedSequenceNumber)
-            {
-                Dispose();
-
-                this.Epoch = 0;
-                this.CanHandleApplicationData = false;
-                this.QueuedApplicationDataMessage.Clear();
-
-                this.CurrentEpoch.NextOutgoingSequence = 2; // Account for our ClientHelloVerify
-                this.CurrentEpoch.NextExpectedSequence = nextExpectedSequenceNumber;
-                this.CurrentEpoch.PreviousSequenceWindowBitmask = 0;
-                this.CurrentEpoch.RecordProtection = NullRecordProtection.Instance;
-                this.CurrentEpoch.PreviousRecordProtection = null;
-                this.CurrentEpoch.ServerFinishedVerification.SecureClear();
-                this.CurrentEpoch.ExpectedClientFinishedVerification.SecureClear();
-
-                this.NextEpoch.State = HandshakeState.ExpectingHello;
-                this.NextEpoch.RecordProtection = null;
-                this.NextEpoch.Handshake = null;
-                this.NextEpoch.ClientRandom = new byte[Random.Size];
-                this.NextEpoch.ServerRandom = new byte[Random.Size];
-                this.NextEpoch.VerificationStream = new Sha256Stream();
-                this.NextEpoch.ClientVerification = new byte[Finished.Size];
-                this.NextEpoch.ServerVerification = new byte[Finished.Size];
-
-                this.ConnectionId = connectionId;
-
-                this.StartOfNegotiation = DateTime.UtcNow;
-            }
-
-            public void Dispose()
-            {
-                this.CurrentEpoch.RecordProtection?.Dispose();
-                this.CurrentEpoch.PreviousRecordProtection?.Dispose();
-                this.NextEpoch.RecordProtection?.Dispose();
-                this.NextEpoch.Handshake?.Dispose();
-                this.NextEpoch.VerificationStream?.Dispose();
-
-                while (this.ApplicationData.TryTake(out var msg))
-                {
-                    try
-                    {
-                        msg.Recycle();
-                    }
-                    catch { }
-                }
-            }
-        }
-
         private RandomNumberGenerator random;
 
         // Private key component of certificate's public key
@@ -387,7 +250,7 @@ namespace Hazel.Dtls
                     }
 
                     // Validate record authenticity
-                    int decryptedSize = peer.CurrentEpoch.RecordProtection.GetDecryptedSize(recordPayload.Length);
+                    int decryptedSize = peer.CurrentEpoch.MasterRecordProtection.GetDecryptedSize(recordPayload.Length);
                     if (decryptedSize < 0)
                     {
                         this.Logger.WriteInfo($"Dropping malformed record: Length {recordPayload.Length} Decrypted length: {decryptedSize}");
@@ -397,7 +260,7 @@ namespace Hazel.Dtls
                     ByteSpan decryptedPayload = recordPayload.ReuseSpanIfPossible(decryptedSize);
                     ProtocolVersion protocolVersion = peer.ProtocolVersion;
 
-                    if (!peer.CurrentEpoch.RecordProtection.DecryptCiphertextFromClient(decryptedPayload, recordPayload, ref record))
+                    if (!peer.CurrentEpoch.MasterRecordProtection.DecryptCiphertextFromClient(decryptedPayload, recordPayload, ref record))
                     {
                         this.Logger.WriteVerbose($"Dropping non-authentic {record.ContentType} record from `{peerAddress}`");
                         return;
@@ -446,10 +309,10 @@ namespace Hazel.Dtls
                             // Migrate to the next epoch
                             peer.Epoch = peer.NextEpoch.Epoch;
                             peer.CanHandleApplicationData = false; // Need a Finished message
-                            peer.CurrentEpoch.NextOutgoingSequenceForPreviousEpoch = peer.CurrentEpoch.NextOutgoingSequence;
+                            peer.CurrentEpoch.NextOutgoingSequenceForPreviousEpoch = (ulong)peer.CurrentEpoch.NextOutgoingSequence;
                             peer.CurrentEpoch.PreviousRecordProtection?.Dispose();
-                            peer.CurrentEpoch.PreviousRecordProtection = peer.CurrentEpoch.RecordProtection;
-                            peer.CurrentEpoch.RecordProtection = peer.NextEpoch.RecordProtection;
+                            peer.CurrentEpoch.PreviousRecordProtection = peer.CurrentEpoch.MasterRecordProtection;
+                            peer.CurrentEpoch.MasterRecordProtection = peer.NextEpoch.RecordProtection;
                             peer.CurrentEpoch.NextOutgoingSequence = 1;
                             peer.CurrentEpoch.NextExpectedSequence = 1;
                             peer.CurrentEpoch.PreviousSequenceWindowBitmask = 0;
@@ -731,8 +594,8 @@ namespace Hazel.Dtls
                         finishedRecord.ContentType = ContentType.Handshake;
                         finishedRecord.ProtocolVersion = protocolVersion;
                         finishedRecord.Epoch = peer.Epoch;
-                        finishedRecord.SequenceNumber = peer.CurrentEpoch.NextOutgoingSequence;
-                        finishedRecord.Length = (ushort)peer.CurrentEpoch.RecordProtection.GetEncryptedSize(plaintextFinishedPayloadSize);
+                        finishedRecord.SequenceNumber = (ulong)peer.CurrentEpoch.NextOutgoingSequence;
+                        finishedRecord.Length = (ushort)peer.CurrentEpoch.MasterRecordProtection.GetEncryptedSize(plaintextFinishedPayloadSize);
                         ++peer.CurrentEpoch.NextOutgoingSequence;
 
                         // Encode the flight into wire format
@@ -758,7 +621,7 @@ namespace Hazel.Dtls
                         );
 
                         // Protect the Finished Handshake record
-                        peer.CurrentEpoch.RecordProtection.EncryptServerPlaintext(
+                        peer.CurrentEpoch.MasterRecordProtection.EncryptServerPlaintext(
                             startOfFinishedRecord.Slice(Record.Size, finishedRecord.Length),
                             startOfFinishedRecord.Slice(Record.Size, plaintextFinishedPayloadSize),
                             ref finishedRecord
@@ -766,8 +629,7 @@ namespace Hazel.Dtls
 
                         // Current epoch can now handle application data
                         peer.CanHandleApplicationData = true;
-
-                        base.QueueRawData(packet, peerAddress);
+                        this.sendQueue.Add(new SendMessageInfo(packet, peerAddress));
                         break;
 
                     // Drop messages that we do not support
@@ -847,7 +709,7 @@ namespace Hazel.Dtls
                         outgoingSequence = peer.CurrentEpoch.NextExpectedSequence;
                         ++peer.CurrentEpoch.NextOutgoingSequenceForPreviousEpoch;
 
-                        recordProtection = peer.CurrentEpoch.RecordProtection;
+                        recordProtection = peer.CurrentEpoch.MasterRecordProtection;
                     }
 
 #if DEBUG
@@ -990,8 +852,8 @@ namespace Hazel.Dtls
             initialRecord.ContentType = ContentType.Handshake;
             initialRecord.ProtocolVersion = protocolVersion;
             initialRecord.Epoch = peer.Epoch;
-            initialRecord.SequenceNumber = peer.CurrentEpoch.NextOutgoingSequence;
-            initialRecord.Length = (ushort)peer.CurrentEpoch.RecordProtection.GetEncryptedSize(initialRecordPayloadSize);
+            initialRecord.SequenceNumber = (ulong)peer.CurrentEpoch.NextOutgoingSequence;
+            initialRecord.Length = (ushort)peer.CurrentEpoch.MasterRecordProtection.GetEncryptedSize(initialRecordPayloadSize);
             ++peer.CurrentEpoch.NextOutgoingSequence;
 
             // Convert initial record of the flight to
@@ -1010,13 +872,13 @@ namespace Hazel.Dtls
             certificateData = certificateData.Slice(certInitialFragmentSize);
 
             // Protect initial record of the flight
-            peer.CurrentEpoch.RecordProtection.EncryptServerPlaintext(
+            peer.CurrentEpoch.MasterRecordProtection.EncryptServerPlaintext(
                 packet.Slice(Record.Size, initialRecord.Length),
                 packet.Slice(Record.Size, initialRecordPayloadSize),
                 ref initialRecord
             );
 
-            base.QueueRawData(packet, peerAddress);
+            this.sendQueue.Add(new SendMessageInfo(packet, peerAddress));
 
             // Record record payload for verification
             if (recordMessagesForVerifyData)
@@ -1054,8 +916,8 @@ namespace Hazel.Dtls
                 additionalRecord.ContentType = ContentType.Handshake;
                 additionalRecord.ProtocolVersion = protocolVersion;
                 additionalRecord.Epoch = peer.Epoch;
-                additionalRecord.SequenceNumber = peer.CurrentEpoch.NextOutgoingSequence;
-                additionalRecord.Length = (ushort)peer.CurrentEpoch.RecordProtection.GetEncryptedSize(additionalRecordPayloadSize);
+                additionalRecord.SequenceNumber = (ulong)peer.CurrentEpoch.NextOutgoingSequence;
+                additionalRecord.Length = (ushort)peer.CurrentEpoch.MasterRecordProtection.GetEncryptedSize(additionalRecordPayloadSize);
                 ++peer.CurrentEpoch.NextOutgoingSequence;
 
                 // Convert record to wire format
@@ -1070,13 +932,13 @@ namespace Hazel.Dtls
                 certificateData = certificateData.Slice(certFragmentSize);
 
                 // Protect record
-                peer.CurrentEpoch.RecordProtection.EncryptServerPlaintext(
+                peer.CurrentEpoch.MasterRecordProtection.EncryptServerPlaintext(
                     packet.Slice(Record.Size, additionalRecord.Length),
                     packet.Slice(Record.Size, additionalRecordPayloadSize),
                     ref additionalRecord
                 );
 
-                base.QueueRawData(packet, peerAddress);
+                this.sendQueue.Add(new SendMessageInfo(packet, peerAddress));
             }
 
             // Describe final record of the flight
@@ -1102,8 +964,8 @@ namespace Hazel.Dtls
             finalRecord.ContentType = ContentType.Handshake;
             finalRecord.ProtocolVersion = protocolVersion;
             finalRecord.Epoch = peer.Epoch;
-            finalRecord.SequenceNumber = peer.CurrentEpoch.NextOutgoingSequence;
-            finalRecord.Length = (ushort)peer.CurrentEpoch.RecordProtection.GetEncryptedSize(finalRecordPayloadSize);
+            finalRecord.SequenceNumber = (ulong)peer.CurrentEpoch.NextOutgoingSequence;
+            finalRecord.Length = (ushort)peer.CurrentEpoch.MasterRecordProtection.GetEncryptedSize(finalRecordPayloadSize);
             ++peer.CurrentEpoch.NextOutgoingSequence;
 
             // Convert final record of the flight to wire
@@ -1130,13 +992,13 @@ namespace Hazel.Dtls
             }
 
             // Protect final record of the flight
-            peer.CurrentEpoch.RecordProtection.EncryptServerPlaintext(
+            peer.CurrentEpoch.MasterRecordProtection.EncryptServerPlaintext(
                 packet.Slice(Record.Size, finalRecord.Length),
                 packet.Slice(Record.Size, finalRecordPayloadSize),
                 ref finalRecord
             );
 
-            base.QueueRawData(packet, peerAddress);
+            this.sendQueue.Add(new SendMessageInfo(packet, peerAddress));
 
             return true;
         }
@@ -1187,7 +1049,7 @@ namespace Hazel.Dtls
             // We only accept Handshake protocol messages from non-peers
             if (record.ContentType != ContentType.Handshake)
             {
-                this.Logger.WriteError($"Dropping non-handhsake message from non-peer `{peerAddress}`");
+                this.Logger.WriteError($"Dropping non-handshake message from non-peer `{peerAddress}`: {record.ContentType}");
                 return;
             }
 
@@ -1275,92 +1137,61 @@ namespace Hazel.Dtls
                 ref record
             );
 
-            base.QueueRawData(packet, peerAddress);
+            this.sendQueue.TryAdd(new SendMessageInfo(packet, peerAddress));
         }
 
         /// <summary>
         /// Handle a requrest to send a datagram to the network
         /// </summary>
-        protected override void QueueRawData(ByteSpan span, IPEndPoint remoteEndPoint)
+        protected override void ProcessQueuedSend(SendMessageInfo msg)
         {
             PeerData peer;
-            if (!this.existingPeers.TryGetValue(remoteEndPoint, out peer))
+            if (!this.existingPeers.TryGetValue(msg.Recipient, out peer))
             {
                 // Drop messages if we don't know how to send them
                 return;
             }
 
-            lock (peer)
+            // If we're negotiating a new epoch, queue data
+            if (peer.Epoch == 0 || peer.NextEpoch.State != HandshakeState.ExpectingHello)
             {
-                // If we're negotiating a new epoch, queue data
-                if (peer.Epoch == 0 || peer.NextEpoch.State != HandshakeState.ExpectingHello)
-                {
-                    ByteSpan copyOfSpan = new byte[span.Length];
-                    span.CopyTo(copyOfSpan);
-
-                    peer.QueuedApplicationDataMessage.Add(copyOfSpan);
-                    return;
-                }
-
-                ProtocolVersion protocolVersion = peer.ProtocolVersion;
-
-                // Send any queued application data now
-                for (int ii = 0, nn = peer.QueuedApplicationDataMessage.Count; ii != nn; ++ii)
-                {
-                    ByteSpan queuedSpan = peer.QueuedApplicationDataMessage[ii];
-
-                    Record outgoingRecord = new Record();
-                    outgoingRecord.ContentType = ContentType.ApplicationData;
-                    outgoingRecord.ProtocolVersion = protocolVersion;
-                    outgoingRecord.Epoch = peer.Epoch;
-                    outgoingRecord.SequenceNumber = peer.CurrentEpoch.NextOutgoingSequence;
-                    outgoingRecord.Length = (ushort)peer.CurrentEpoch.RecordProtection.GetEncryptedSize(queuedSpan.Length);
-                    ++peer.CurrentEpoch.NextOutgoingSequence;
-
-                    // Encode the record to wire format
-                    ByteSpan packet = new byte[Record.Size + outgoingRecord.Length];
-                    ByteSpan writer = packet;
-                    outgoingRecord.Encode(writer);
-                    writer = writer.Slice(Record.Size);
-                    queuedSpan.CopyTo(writer);
-
-                    // Protect the record
-                    peer.CurrentEpoch.RecordProtection.EncryptServerPlaintext(
-                        packet.Slice(Record.Size, outgoingRecord.Length),
-                        packet.Slice(Record.Size, queuedSpan.Length),
-                        ref outgoingRecord
-                    );
-
-                    base.QueueRawData(packet, remoteEndPoint);
-                }
-                peer.QueuedApplicationDataMessage.Clear();
-
-                {
-                    Record outgoingRecord = new Record();
-                    outgoingRecord.ContentType = ContentType.ApplicationData;
-                    outgoingRecord.ProtocolVersion = protocolVersion;
-                    outgoingRecord.Epoch = peer.Epoch;
-                    outgoingRecord.SequenceNumber = peer.CurrentEpoch.NextOutgoingSequence;
-                    outgoingRecord.Length = (ushort)peer.CurrentEpoch.RecordProtection.GetEncryptedSize(span.Length);
-                    ++peer.CurrentEpoch.NextOutgoingSequence;
-
-                    // Encode the record to wire format
-                    ByteSpan packet = new byte[Record.Size + outgoingRecord.Length];
-                    ByteSpan writer = packet;
-                    outgoingRecord.Encode(writer);
-                    writer = writer.Slice(Record.Size);
-                    span.CopyTo(writer);
-
-                    // Protect the record
-                    peer.CurrentEpoch.RecordProtection.EncryptServerPlaintext(
-                        packet.Slice(Record.Size, outgoingRecord.Length),
-                        packet.Slice(Record.Size, span.Length),
-                        ref outgoingRecord
-                    );
-
-                    base.QueueRawData(packet, remoteEndPoint);
-                }
+                peer.QueuedApplicationDataMessage.Enqueue(msg.Span);
+                return;
             }
+
+            // Send any queued application data now
+            while (peer.QueuedApplicationDataMessage.TryDequeue(out var queuedSpan))
+            {
+                EncryptEnqueueApplicationDataRecord(msg, peer, queuedSpan);
+            }
+
+            EncryptEnqueueApplicationDataRecord(msg, peer, msg.Span);
+        }
+
+        private void EncryptEnqueueApplicationDataRecord(SendMessageInfo msg, PeerData peer, ByteSpan queuedSpan)
+        {
+            Record outgoingRecord = new Record();
+            outgoingRecord.ContentType = ContentType.ApplicationData;
+            outgoingRecord.ProtocolVersion = peer.ProtocolVersion;
+            outgoingRecord.Epoch = peer.Epoch;
+            outgoingRecord.SequenceNumber = (ulong)Interlocked.Increment(ref peer.CurrentEpoch.NextOutgoingSequence);
+            outgoingRecord.Length = (ushort)peer.CurrentEpoch.MasterRecordProtection.GetEncryptedSize(queuedSpan.Length);
+
+            // Encode the record to wire format
+            ByteSpan packet = new byte[Record.Size + outgoingRecord.Length];
+            ByteSpan writer = packet;
+            outgoingRecord.Encode(writer);
+            writer = writer.Slice(Record.Size);
+            queuedSpan.CopyTo(writer);
+
+            // Protect the record
+            peer.CurrentEpoch.EncryptServerPlaintext_ThreadSafe(
+                packet.Slice(Record.Size, outgoingRecord.Length),
+                packet.Slice(Record.Size, queuedSpan.Length),
+                ref outgoingRecord
+            );
+
+            this.sendQueue.TryAdd(new SendMessageInfo(packet, msg.Recipient));
         }
 
         private void HandleStaleConnections(object _)

--- a/Hazel/Dtls/DtlsMiscStructs.cs
+++ b/Hazel/Dtls/DtlsMiscStructs.cs
@@ -1,0 +1,111 @@
+﻿using Hazel.Crypto;
+using System;
+using System.Collections.Generic;
+
+namespace Hazel.Dtls
+{
+    /// <summary>
+    /// Current state of handshake sequence
+    /// </summary>
+    internal enum HandshakeState
+    {
+        ExpectingHello,
+        ExpectingClientKeyExchange,
+        ExpectingChangeCipherSpec,
+        ExpectingFinish
+    }
+
+    /// <summary>
+    /// State to manage the current epoch `N`
+    /// </summary>
+    internal struct CurrentEpoch
+    {
+        public long NextOutgoingSequence;
+
+        public ulong NextExpectedSequence;
+        public ulong PreviousSequenceWindowBitmask;
+
+        public IRecordProtection MasterRecordProtection;
+        public IRecordProtection PreviousRecordProtection;
+
+        [ThreadStatic]
+        private IRecordProtection recordProtection;
+        private List<IRecordProtection> allRecordProtections;
+
+        // Need to keep these around so we can re-transmit our
+        // last handshake record flight
+        public ByteSpan ExpectedClientFinishedVerification;
+        public ByteSpan ServerFinishedVerification;
+        public ulong NextOutgoingSequenceForPreviousEpoch;
+
+        public void Init()
+        {
+            ByteSpan block = new byte[2 * Finished.Size];
+            this.ServerFinishedVerification = block.Slice(0, Finished.Size);
+            this.ExpectedClientFinishedVerification = block.Slice(Finished.Size, Finished.Size);
+            this.allRecordProtections = new List<IRecordProtection>();
+        }
+
+        public void EncryptServerPlaintext_ThreadSafe(ByteSpan output, ByteSpan input, ref Record record)
+        {
+            if (this.recordProtection == null
+                || this.recordProtection.Id != this.MasterRecordProtection.Id)
+            {
+                if (this.recordProtection != null)
+                {
+                    this.recordProtection.Dispose();
+                    lock (this.allRecordProtections)
+                    {
+                        this.allRecordProtections.Remove(this.recordProtection);
+                    }
+                }
+
+                this.recordProtection = this.MasterRecordProtection.Duplicate();
+                lock (this.allRecordProtections)
+                {
+                    this.allRecordProtections.Add(this.recordProtection);
+                }
+            }
+
+            this.recordProtection.EncryptServerPlaintext(output, input, ref record);
+        }
+
+        public void DisposeThreadStatics()
+        {
+            lock (this.allRecordProtections)
+            {
+                foreach (var i in this.allRecordProtections)
+                {
+                    i.Dispose();
+                }
+
+                this.allRecordProtections.Clear();
+            }
+        }
+    }
+
+    /// <summary>
+    /// State to manage the transition from the current
+    /// epoch `N` to epoch `N+1`
+    /// </summary>
+    internal struct NextEpoch
+    {
+        public ushort Epoch;
+
+        public HandshakeState State;
+        public CipherSuite SelectedCipherSuite;
+
+        public ulong NextOutgoingSequence;
+
+        public IHandshakeCipherSuite Handshake;
+        public IRecordProtection RecordProtection;
+
+        public ByteSpan ClientRandom;
+        public ByteSpan ServerRandom;
+
+        public Sha256Stream VerificationStream;
+
+        public ByteSpan ClientVerification;
+        public ByteSpan ServerVerification;
+    }
+}

--- a/Hazel/Dtls/DtlsPeerData.cs
+++ b/Hazel/Dtls/DtlsPeerData.cs
@@ -1,0 +1,89 @@
+﻿using Hazel.Crypto;
+using Hazel.Udp.FewerThreads;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+
+namespace Hazel.Dtls
+{
+    /// <summary>
+    /// Per-peer state
+    /// </summary>
+    internal sealed class PeerData : IDisposable
+    {
+        public ushort Epoch;
+        public bool CanHandleApplicationData;
+
+        public HazelDtlsSessionInfo Session;
+
+        public CurrentEpoch CurrentEpoch;
+        public NextEpoch NextEpoch;
+
+        public ConnectionId ConnectionId;
+
+        public readonly ConcurrentQueue<ByteSpan> QueuedApplicationDataMessage = new ConcurrentQueue<ByteSpan>();
+        public readonly ConcurrentBag<MessageReader> ApplicationData = new ConcurrentBag<MessageReader>();
+        public readonly ProtocolVersion ProtocolVersion;
+
+        public DateTime StartOfNegotiation;
+
+        public PeerData(ConnectionId connectionId, ulong nextExpectedSequenceNumber, ProtocolVersion protocolVersion)
+        {
+            this.CurrentEpoch.Init();
+            this.ProtocolVersion = protocolVersion;
+
+            ResetPeer(connectionId, nextExpectedSequenceNumber);
+        }
+
+        public void ResetPeer(ConnectionId connectionId, ulong nextExpectedSequenceNumber)
+        {
+            Dispose();
+
+            this.Epoch = 0;
+            this.CanHandleApplicationData = false;
+            while (this.QueuedApplicationDataMessage.TryDequeue(out _));
+
+            this.CurrentEpoch.NextOutgoingSequence = 2; // Account for our ClientHelloVerify
+            this.CurrentEpoch.NextExpectedSequence = nextExpectedSequenceNumber;
+            this.CurrentEpoch.PreviousSequenceWindowBitmask = 0;
+            this.CurrentEpoch.MasterRecordProtection = NullRecordProtection.Instance;
+            this.CurrentEpoch.PreviousRecordProtection = null;
+            this.CurrentEpoch.ServerFinishedVerification.SecureClear();
+            this.CurrentEpoch.ExpectedClientFinishedVerification.SecureClear();
+
+            this.NextEpoch.State = HandshakeState.ExpectingHello;
+            this.NextEpoch.RecordProtection = null;
+            this.NextEpoch.Handshake = null;
+            this.NextEpoch.ClientRandom = new byte[Random.Size];
+            this.NextEpoch.ServerRandom = new byte[Random.Size];
+            this.NextEpoch.VerificationStream = new Sha256Stream();
+            this.NextEpoch.ClientVerification = new byte[Finished.Size];
+            this.NextEpoch.ServerVerification = new byte[Finished.Size];
+
+            this.ConnectionId = connectionId;
+
+            this.StartOfNegotiation = DateTime.UtcNow;
+        }
+
+        public void Dispose()
+        {
+            this.CurrentEpoch.MasterRecordProtection?.Dispose();
+            this.CurrentEpoch.PreviousRecordProtection?.Dispose();
+            this.CurrentEpoch.DisposeThreadStatics();
+
+            this.NextEpoch.RecordProtection?.Dispose();
+            this.NextEpoch.Handshake?.Dispose();
+            this.NextEpoch.VerificationStream?.Dispose();
+
+            while (this.ApplicationData.TryTake(out var msg))
+            {
+                try
+                {
+                    msg.Recycle();
+                }
+                catch { }
+            }
+        }
+    }
+
+}

--- a/Hazel/Dtls/IRecordProtection.cs
+++ b/Hazel/Dtls/IRecordProtection.cs
@@ -8,6 +8,11 @@ namespace Hazel.Dtls
     public interface IRecordProtection : IDisposable
     {
         /// <summary>
+        /// An id shared by this record protection and all its copies
+        /// </summary>
+        int Id { get; }
+
+        /// <summary>
         /// Calculate the size of an encrypted plaintext
         /// </summary>
         /// <param name="dataSize">Size of plaintext in bytes</param>
@@ -62,6 +67,11 @@ namespace Hazel.Dtls
         /// <param name="record">Parent DTLS record</param>
         /// <returns>True if the input was authenticated and decrypted. Otherwise false</returns>
         bool DecryptCiphertextFromClient(ByteSpan output, ByteSpan input, ref Record record);
+
+        /// <summary>
+        /// Creates an exact duplicate of this instance.
+        /// </summary>
+        IRecordProtection Duplicate();
     }
 
     /// <summary>

--- a/Hazel/Dtls/NullRecordProtection.cs
+++ b/Hazel/Dtls/NullRecordProtection.cs
@@ -11,6 +11,8 @@ namespace Hazel.Dtls
     /// </summary>
     public class NullRecordProtection : IRecordProtection
     {
+        public int Id => -1;
+
         public readonly static NullRecordProtection Instance = new NullRecordProtection();
 
         public void Dispose()
@@ -47,6 +49,11 @@ namespace Hazel.Dtls
         {
             CopyMaybeOverlappingSpans(output, input);
             return true;
+        }
+
+        public IRecordProtection Duplicate()
+        {
+            return this;
         }
 
         private static void CopyMaybeOverlappingSpans(ByteSpan output, ByteSpan input)

--- a/Hazel/FewerThreads/ConnectionId.cs
+++ b/Hazel/FewerThreads/ConnectionId.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Net;
+
+namespace Hazel.Udp.FewerThreads
+{
+    public struct ConnectionId : IEquatable<ConnectionId>
+    {
+        public IPEndPoint EndPoint;
+        public int Serial;
+
+        public static ConnectionId Create(IPEndPoint endPoint, int serial)
+        {
+            return new ConnectionId
+            {
+                EndPoint = endPoint,
+                Serial = serial,
+            };
+        }
+
+        public bool Equals(ConnectionId other)
+        {
+            return this.Serial == other.Serial
+                && this.EndPoint.Equals(other.EndPoint)
+                ;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is ConnectionId)
+            {
+                return this.Equals((ConnectionId)obj);
+            }
+
+            return false;
+        }
+
+        public override int GetHashCode()
+        {
+            ///NOTE(mendsley): We're only hashing the endpoint
+            /// here, as the common case will have one
+            /// connection per address+port tuple.
+            return this.EndPoint.GetHashCode();
+        }
+    }
+}

--- a/Hazel/FewerThreads/HazelPipelineSegment.cs
+++ b/Hazel/FewerThreads/HazelPipelineSegment.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Threading;
+
+namespace Hazel
+{
+    public class HazelPipelineSegment<InputType> : IDisposable
+    {
+        private readonly HazelThreadPool threads;
+        private readonly BlockingCollection<InputType> inputs = new BlockingCollection<InputType>();
+        private readonly Action<InputType> factory;
+
+        public int Count => this.inputs.Count;
+
+        public HazelPipelineSegment(int numThreads, Action<InputType> factory)
+        {
+            this.threads = new HazelThreadPool(numThreads, RunProcessing);
+            this.factory = factory;
+        }
+
+        private void RunProcessing()
+        {
+            while (this.inputs.TryTake(out var item, Timeout.Infinite))
+            {
+                this.factory(item);
+            }
+        }
+
+        public void Start()
+        {
+            this.threads.Start();
+        }
+
+        public void Join()
+        {
+            this.inputs.CompleteAdding();
+            this.threads.Join();
+        }
+
+        public void AddInput(InputType item)
+        {
+            this.inputs.TryAdd(item);
+        }
+
+        public void Dispose()
+        {
+            this.inputs.Dispose();
+        }
+    }
+}

--- a/Hazel/FewerThreads/HazelThreadPool.cs
+++ b/Hazel/FewerThreads/HazelThreadPool.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace Hazel
 {
-    internal class HazelThreadPool
+    public class HazelThreadPool
     {
         private Thread[] threads;
 

--- a/Hazel/FewerThreads/ThreadLimitedUdpServerConnection.cs
+++ b/Hazel/FewerThreads/ThreadLimitedUdpServerConnection.cs
@@ -20,7 +20,7 @@ namespace Hazel.Udp.FewerThreads
         /// </remarks>
         public ThreadLimitedUdpConnectionListener Listener { get; private set; }
 
-        public ThreadLimitedUdpConnectionListener.ConnectionId ConnectionId { get; private set; }
+        public ConnectionId ConnectionId { get; private set; }
 
         /// <summary>
         ///     Creates a UdpConnection for the virtual connection to the endpoint.
@@ -28,7 +28,7 @@ namespace Hazel.Udp.FewerThreads
         /// <param name="listener">The listener that created this connection.</param>
         /// <param name="endPoint">The endpoint that we are connected to.</param>
         /// <param name="IPMode">The IPMode we are connected using.</param>
-        internal ThreadLimitedUdpServerConnection(ThreadLimitedUdpConnectionListener listener, ThreadLimitedUdpConnectionListener.ConnectionId connectionId, IPEndPoint endPoint, IPMode IPMode, ILogger logger)
+        internal ThreadLimitedUdpServerConnection(ThreadLimitedUdpConnectionListener listener, ConnectionId connectionId, IPEndPoint endPoint, IPMode IPMode, ILogger logger)
             : base(logger)
         {
             this.Listener = listener;
@@ -49,7 +49,7 @@ namespace Hazel.Udp.FewerThreads
             // but I don't want to have a bunch of client references in the send queue...
             // Does this perhaps mean the encryption is being done in the wrong class?
             this.Statistics.LogPacketSend(length);
-            Listener.SendDataRaw(bytes, EndPoint);
+            this.Listener.SendDataRaw(bytes, EndPoint);
         }
 
         /// <inheritdoc />
@@ -89,7 +89,7 @@ namespace Hazel.Udp.FewerThreads
 
             try
             {
-                this.WriteBytesToConnection(bytes, bytes.Length);
+                this.Listener.SendDisconnect(bytes, this.EndPoint);
             }
             catch { }
 

--- a/Hazel/MessageWriter.cs
+++ b/Hazel/MessageWriter.cs
@@ -135,6 +135,13 @@ namespace Hazel
 
         #region WriteMethods
 
+        public void CopyFrom(MessageWriter target)
+        {
+            target.SendOption = target.SendOption;
+            System.Buffer.BlockCopy(target.Buffer, 0, this.Buffer, 0, target.Length);
+            this.Position = this.Length = target.Length;
+        }
+
         public void CopyFrom(MessageReader target)
         {
             int offset, length;


### PR DESCRIPTION
This only affects application data packets. Receives and internal sends like handshakes still lock the peer to avoid untangling that whole mess, but in principle, the pattern would support all of it.

Adding more threads into the send process creates some gotchas with disconnecting, so I also had to make a more synchronous path to ensure the encryption context is valid when we want to disconnect.

- HazelPipelineSegment is a new wrapper around a blocking collection and thread pool. Technically receive workers could also be refactored to use one of these, but I didn't wanna go too crazy.
- Moved some of the private DTLS structs into new files.
- Also cleaned up and made some of the core tests more reliable.