### PR TITLE
Remove the PingPacket pool for a small fixed array of recent pings

### DIFF
--- a/Hazel/Tools/PingBuffer.cs
+++ b/Hazel/Tools/PingBuffer.cs
@@ -1,0 +1,62 @@
+﻿using System;
+
+namespace Hazel.Tools
+{
+    public class PingBuffer
+    {
+        private const ushort InvalidatingFactor = ushort.MaxValue / 2;
+
+        private struct PingInfo
+        {
+            public ushort Id;
+            public DateTime SentAt;
+        }
+
+        private PingInfo[] activePings;
+        private int head; // The location of the next usable activePing
+
+        public PingBuffer(int maxPings)
+        {
+            this.activePings = new PingInfo[maxPings];
+
+            // We don't want the first few packets to match id before we set anything.
+            for (int i = 0; i < this.activePings.Length; ++i)
+            {
+                this.activePings[i].Id = InvalidatingFactor;
+            }
+        }
+
+        public void AddPing(ushort id)
+        {
+            lock (this.activePings)
+            {
+                this.activePings[this.head].Id = id;
+                this.activePings[this.head].SentAt = DateTime.UtcNow;
+                this.head++;
+                if (this.head >= this.activePings.Length)
+                {
+                    this.head = 0;
+                }
+            }
+        }
+
+        public bool TryFindPing(ushort id, out DateTime sentAt)
+        {
+            lock (this.activePings)
+            {
+                for (int i = 0; i < this.activePings.Length; ++i)
+                {
+                    if (this.activePings[i].Id == id)
+                    {
+                        sentAt = this.activePings[i].SentAt;
+                        this.activePings[i].Id += InvalidatingFactor;
+                        return true;
+                    }
+                }
+            }
+
+            sentAt = default;
+            return false;
+        }
+    }
+}

--- a/Hazel/Udp/UdpConnection.Reliable.cs
+++ b/Hazel/Udp/UdpConnection.Reliable.cs
@@ -427,11 +427,9 @@ namespace Hazel.Udp
                     this._pingMs = this._pingMs * .7f + rt * .3f;
                 }
             }
-            else if (this.activePingPackets.TryRemove(id, out PingPacket pingPkt))
+            else if (this.activePings.TryFindPing(id, out DateTime pingPkt))
             {
-                float rt = pingPkt.Stopwatch.ElapsedMilliseconds;
-
-                pingPkt.Recycle();
+                float rt = (float)(DateTime.UtcNow - pingPkt).TotalMilliseconds;
 
                 lock (PingLock)
                 {


### PR DESCRIPTION
Pretty simple. Under very heavy load, this will keep pings from pooling up and consuming lots of memory. I think it should still be pretty performant because the ping buffer array is very small and cache-friendly. I think anything better than this would require creating separate "Pong" packets to avoid falling back from reliable acks to ping acks.