### PR TITLE
Make reader size configurable and reduce the default

### DIFF
--- a/Hazel.UnitTests/SocketCapture.cs
+++ b/Hazel.UnitTests/SocketCapture.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;
+using System.Text;
 using System.Threading;
 
 namespace Hazel.UnitTests
@@ -252,11 +253,40 @@ namespace Hazel.UnitTests
             }
         }
 
+        internal void ReleasePacketsForRemote(int numToSend)
+        {
+            var newExpected = this.forRemote.Count - numToSend;
+            this.SendToRemoteSemaphore.Release(numToSend);
+            this.AssertPacketsToRemoteCountEquals(newExpected);
+        }
+
         internal void ReleasePacketsToLocal(int numToSend)
         {
             var newExpected = this.forLocal.Count - numToSend;
-            this.SendToLocalSemaphore.Release();
+            this.SendToLocalSemaphore.Release(numToSend);
             this.AssertPacketsToLocalCountEquals(newExpected);
+        }
+
+        internal string PacketsForRemoteToString()
+        {
+            StringBuilder sb = new StringBuilder();
+            foreach (var item in this.forRemote)
+            {
+                sb.AppendLine(item.ToString());
+            }
+
+            return sb.ToString();
+        }
+
+        internal string PacketsForLocalToString()
+        {
+            StringBuilder sb = new StringBuilder();
+            foreach(var item in this.forLocal)
+            {
+                sb.AppendLine(item.ToString());
+            }
+
+            return sb.ToString();
         }
     }
 }

--- a/Hazel.UnitTests/ThreadLimitedUdpConnectionTests.cs
+++ b/Hazel.UnitTests/ThreadLimitedUdpConnectionTests.cs
@@ -342,14 +342,16 @@ namespace Hazel.UnitTests
                     // Drop the middle packet
                     capture.AssertPacketsToRemoteCountEquals(3);
                     capture.ReorderPacketsForRemote(list => list.Sort(SortByPacketId.Instance));
+                    Console.WriteLine(capture.PacketsForRemoteToString());
 
-                    capture.SendToRemoteSemaphore.Release();
+                    capture.ReleasePacketsForRemote(1);
                     capture.DiscardPacketForRemote();
-                    capture.SendToRemoteSemaphore.Release();
+                    capture.ReleasePacketsForRemote(1);
 
                     // Receive 2 acks
                     capture.AssertPacketsToLocalCountEquals(2);
                     capture.ReorderPacketsForLocal(list => list.Sort(SortByPacketId.Instance));
+                    Console.WriteLine(capture.PacketsForLocalToString());
 
                     var ack1 = capture.PeekPacketForLocal();
                     Assert.AreEqual(10, ack1[0]); // enum SendOptionInternal.Acknowledgement

--- a/Hazel/ConnectionListener.cs
+++ b/Hazel/ConnectionListener.cs
@@ -20,6 +20,18 @@ namespace Hazel
     /// <threadsafety static="true" instance="true"/>
     public abstract class ConnectionListener : IDisposable
     {
+        /// <summary>
+        /// The max size Hazel attempts to read from the network.
+        /// Defaults to 8096.
+        /// </summary>
+        /// <remarks>
+        /// 8096 is 5 times the standard modern MTU of 1500, so it's already too large imo.
+        /// If Hazel ever implements fragmented packets, then we might consider a larger value since combining 5 
+        /// packets into 1 reader would be realistic and would cause reallocations. That said, Hazel is not meant
+        /// for transferring large contiguous blocks of data, so... please don't?
+        /// </remarks>
+        public int ReceiveBufferSize = 8096;
+
         public readonly ListenerStatistics Statistics = new ListenerStatistics();
 
         public abstract double AveragePing { get; }

--- a/Hazel/FewerThreads/ThreadLimitedUdpConnectionListener.cs
+++ b/Hazel/FewerThreads/ThreadLimitedUdpConnectionListener.cs
@@ -27,7 +27,6 @@ namespace Hazel.Udp.FewerThreads
         }
 
         private const int SendReceiveBufferSize = 1024 * 1024;
-        private const int BufferSize = ushort.MaxValue;
 
         private Socket socket;
         protected ILogger Logger;
@@ -186,7 +185,7 @@ namespace Hazel.Udp.FewerThreads
                     if (!isActive) break;
 
                     EndPoint remoteEP = new IPEndPoint(this.EndPoint.Address, this.EndPoint.Port);
-                    MessageReader message = MessageReader.GetSized(BufferSize);
+                    var message = MessageReader.GetSized(this.ReceiveBufferSize);
                     try
                     {
                         message.Length = socket.ReceiveFrom(message.Buffer, 0, message.Buffer.Length, SocketFlags.None, ref remoteEP);

--- a/Hazel/Udp/UdpClientConnection.cs
+++ b/Hazel/Udp/UdpClientConnection.cs
@@ -13,6 +13,18 @@ namespace Hazel.Udp
     public sealed class UdpClientConnection : UdpConnection
     {
         /// <summary>
+        /// The max size Hazel attempts to read from the network.
+        /// Defaults to 8096.
+        /// </summary>
+        /// <remarks>
+        /// 8096 is 5 times the standard modern MTU of 1500, so it's already too large imo.
+        /// If Hazel ever implements fragmented packets, then we might consider a larger value since combining 5 
+        /// packets into 1 reader would be realistic and would cause reallocations. That said, Hazel is not meant
+        /// for transferring large contiguous blocks of data, so... please don't?
+        /// </remarks>
+        public int ReceiveBufferSize = 8096;
+
+        /// <summary>
         ///     The socket we're connected via.
         /// </summary>
         private Socket socket;
@@ -193,7 +205,7 @@ namespace Hazel.Udp
             }
 #endif
 
-            var msg = MessageReader.GetSized(ushort.MaxValue);
+            var msg = MessageReader.GetSized(this.ReceiveBufferSize);
             try
             {
                 socket.BeginReceive(msg.Buffer, 0, msg.Buffer.Length, SocketFlags.None, ReadCallback, msg);

--- a/Hazel/Udp/UdpConnection.cs
+++ b/Hazel/Udp/UdpConnection.cs
@@ -9,7 +9,6 @@ namespace Hazel.Udp
     /// <inheritdoc />
     public abstract partial class UdpConnection : NetworkConnection
     {
-        private const int SioUdpConnectionReset = -1744830452;
         public static readonly byte[] EmptyDisconnectBytes = new byte[] { (byte)UdpSendOption.Disconnect };
 
         public override float AveragePingMs => this._pingMs;

--- a/Hazel/Udp/UdpConnectionListener.cs
+++ b/Hazel/Udp/UdpConnectionListener.cs
@@ -90,7 +90,7 @@ namespace Hazel.Udp
             MessageReader message = null;
             try
             {
-                message = MessageReader.GetSized(BufferSize);
+                message = MessageReader.GetSized(this.ReceiveBufferSize);
                 socket.BeginReceiveFrom(message.Buffer, 0, message.Buffer.Length, SocketFlags.None, ref remoteEP, ReadCallback, message);
             }
             catch (SocketException sx)

--- a/Hazel/Udp/UnityUdpClientConnection.cs
+++ b/Hazel/Udp/UnityUdpClientConnection.cs
@@ -12,6 +12,18 @@ namespace Hazel.Udp
     /// <inheritdoc/>
     public class UnityUdpClientConnection : UdpConnection
     {
+        /// <summary>
+        /// The max size Hazel attempts to read from the network.
+        /// Defaults to 8096.
+        /// </summary>
+        /// <remarks>
+        /// 8096 is 5 times the standard modern MTU of 1500, so it's already too large imo.
+        /// If Hazel ever implements fragmented packets, then we might consider a larger value since combining 5 
+        /// packets into 1 reader would be realistic and would cause reallocations. That said, Hazel is not meant
+        /// for transferring large contiguous blocks of data, so... please don't?
+        /// </remarks>
+        public int ReceiveBufferSize = 8096;
+
         private Socket socket;
 
         public UnityUdpClientConnection(ILogger logger, IPEndPoint remoteEndPoint, IPMode ipMode = IPMode.IPv4)
@@ -205,7 +217,7 @@ namespace Hazel.Udp
         /// </summary>
         void StartListeningForData()
         {
-            var msg = MessageReader.GetSized(ushort.MaxValue);
+            var msg = MessageReader.GetSized(this.ReceiveBufferSize);
             try
             {
                 EndPoint ep = this.EndPoint;


### PR DESCRIPTION
I didn't put the variable in Connection or UdpConnection because it would affect the *ServerConnection classes, but never be used.

Also I happened to see an unused const. I liked the locally-scoped version better currently in use.

Also fixed a flaky test:
1. We enqueue packets 1, 2, 3 for remote. 
2. Release semaphore once, drop 2, release semaphore once. 
3. In debug or if you run just the one test in release, this works and the remoteresponds ack 1, 3. 
4. If you run the tests in sequence in release, then releasing the semaphore doesn't pull packet 1 off the queue, fast enough so drop 2 becomes drop 1 and the remote responds ack 2, 3.