### PR TITLE
Reduce allocations with internal smart buffering

### DIFF
--- a/Hazel.UnitTests/TestHelper.cs
+++ b/Hazel.UnitTests/TestHelper.cs
@@ -1,11 +1,8 @@
-using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-
-using Hazel;
-using System.Net;
-using System.Threading;
-using System.Diagnostics;
 using Hazel.Udp.FewerThreads;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Diagnostics;
+using System.Threading;
 
 namespace Hazel.UnitTests
 {
@@ -60,6 +57,7 @@ namespace Hazel.UnitTests
             }
 
             Assert.AreEqual(sendOption, result.Value.SendOption);
+            Assert.AreEqual(0, listener.BuffersInUse, "Some listener buffers are still in use...");
         }
 
         /// <summary>
@@ -110,6 +108,7 @@ namespace Hazel.UnitTests
             }
 
             Assert.AreEqual(sendOption, result.Value.SendOption);
+            Assert.AreEqual(0, listener.BuffersInUse, "Some listener buffers are still in use...");
         }
 
         /// <summary>
@@ -160,6 +159,7 @@ namespace Hazel.UnitTests
             }
 
             Assert.AreEqual(sendOption, result.Value.SendOption);
+            Assert.AreEqual(0, listener.BuffersInUse, "Some listener buffers are still in use...");
         }
 
 
@@ -211,6 +211,7 @@ namespace Hazel.UnitTests
             }
 
             Assert.AreEqual(sendOption, result.Value.SendOption);
+            Assert.AreEqual(0, listener.BuffersInUse, "Some listener buffers are still in use...");
         }
 
         /// <summary>

--- a/Hazel.UnitTests/TestHelper.cs
+++ b/Hazel.UnitTests/TestHelper.cs
@@ -47,7 +47,7 @@ namespace Hazel.UnitTests
             connection.Connect();
 
             //Wait until data is received
-            mutex.WaitOne();
+            mutex.WaitOne(100);
 
             var dataReader = ConvertToMessageReader(data);
             Assert.AreEqual(dataReader.Length, result.Value.Message.Length);

--- a/Hazel.UnitTests/TestHelper.cs
+++ b/Hazel.UnitTests/TestHelper.cs
@@ -57,7 +57,7 @@ namespace Hazel.UnitTests
             }
 
             Assert.AreEqual(sendOption, result.Value.SendOption);
-            Assert.AreEqual(0, listener.BuffersInUse, "Some listener buffers are still in use...");
+            TimedAssertTrue(() => 0 == listener.BuffersInUse, "Some listener buffers are still in use...");
         }
 
         /// <summary>
@@ -108,7 +108,7 @@ namespace Hazel.UnitTests
             }
 
             Assert.AreEqual(sendOption, result.Value.SendOption);
-            Assert.AreEqual(0, listener.BuffersInUse, "Some listener buffers are still in use...");
+            TimedAssertTrue(() => 0 == listener.BuffersInUse, "Some listener buffers are still in use...");
         }
 
         /// <summary>
@@ -159,7 +159,7 @@ namespace Hazel.UnitTests
             }
 
             Assert.AreEqual(sendOption, result.Value.SendOption);
-            Assert.AreEqual(0, listener.BuffersInUse, "Some listener buffers are still in use...");
+            TimedAssertTrue(() => 0 == listener.BuffersInUse, "Some listener buffers are still in use...");
         }
 
 
@@ -211,7 +211,7 @@ namespace Hazel.UnitTests
             }
 
             Assert.AreEqual(sendOption, result.Value.SendOption);
-            Assert.AreEqual(0, listener.BuffersInUse, "Some listener buffers are still in use...");
+            TimedAssertTrue(() => 0 == listener.BuffersInUse, "Some listener buffers are still in use...");
         }
 
         /// <summary>
@@ -333,6 +333,21 @@ namespace Hazel.UnitTests
             }
 
             return output;
+        }
+
+        public static void TimedAssertTrue(Func<bool> assertion, string message, int timeoutMs = 100)
+        {
+            TimeSpan max = TimeSpan.FromMilliseconds(timeoutMs);
+            DateTime start = DateTime.UtcNow;
+            while ((DateTime.UtcNow - start) < max)
+            {
+                if (assertion())
+                {
+                    return;
+                }
+            }
+
+            Assert.IsTrue(assertion(), message);
         }
     }
 }

--- a/Hazel.UnitTests/ThreadLimitedUdpConnectionTests.cs
+++ b/Hazel.UnitTests/ThreadLimitedUdpConnectionTests.cs
@@ -137,6 +137,8 @@ namespace Hazel.UnitTests
                 {
                     Assert.AreEqual(TestData[i], output.ReadByte());
                 }
+
+                Assert.AreEqual(0, listener.BuffersInUse, "Some listener buffers are still in use...");
             }
         }
 
@@ -172,6 +174,8 @@ namespace Hazel.UnitTests
                 {
                     Assert.AreEqual(TestData[i], output.ReadByte());
                 }
+
+                Assert.AreEqual(0, listener.BuffersInUse, "Some listener buffers are still in use...");
             }
         }
 
@@ -241,6 +245,7 @@ namespace Hazel.UnitTests
                 }
 
                 Assert.AreEqual(NumberOfPacketsToResend * NumberOfTimesToResend, connection.Statistics.MessagesResent);
+                Assert.AreEqual(0, listener.BuffersInUse, "Some listener buffers are still in use...");
             }
         }
 
@@ -298,6 +303,7 @@ namespace Hazel.UnitTests
                 // +1 for Hello packet
                 Thread.Sleep(100); // The final ack has to actually be processed.
                 Assert.AreEqual(1 + NumberOfPacketsToSend, connection.Statistics.ReliablePacketsAcknowledged);
+                Assert.AreEqual(0, listener.BuffersInUse, "Some listener buffers are still in use...");
             }
         }
 
@@ -371,6 +377,7 @@ namespace Hazel.UnitTests
                 // +1 for Hello packet, +2 for reliable
                 Thread.Sleep(100); // The final ack has to actually be processed.
                 Assert.AreEqual(3, connection.Statistics.ReliablePacketsAcknowledged);
+                Assert.AreEqual(0, listener.BuffersInUse, "Some listener buffers are still in use...");
             }
         }
 

--- a/Hazel.UnitTests/UdpConnectionTestHarness.cs
+++ b/Hazel.UnitTests/UdpConnectionTestHarness.cs
@@ -43,9 +43,12 @@ namespace Hazel.UnitTests
             return true;
         }
 
-        protected override void WriteBytesToConnection(byte[] bytes, int length)
+        protected override void WriteBytesToConnection(SmartBuffer bytes, int length)
         {
-            this.BytesSent.Add(MessageReader.Get(bytes));
+            var buffer = new byte[bytes.Length];
+            Buffer.BlockCopy((byte[])bytes, 0, buffer, 0, bytes.Length);
+
+            this.BytesSent.Add(MessageReader.Get(buffer));
         }
 
         public void Test_Receive(MessageWriter msg)

--- a/Hazel/ConnectionListener.cs
+++ b/Hazel/ConnectionListener.cs
@@ -39,6 +39,13 @@ namespace Hazel
         public abstract int SendQueueLength { get; }
         public abstract int ReceiveQueueLength { get; }
 
+        protected ObjectPool<SmartBuffer> bufferPool;
+
+        public ConnectionListener()
+        {
+            this.bufferPool = new ObjectPool<SmartBuffer>(() => new SmartBuffer(this.bufferPool, 1024));
+        }
+
         /// <summary>
         /// A callback for early connection rejection. 
         /// * Return false to reject connection.

--- a/Hazel/ConnectionListener.cs
+++ b/Hazel/ConnectionListener.cs
@@ -38,8 +38,9 @@ namespace Hazel
         public abstract int ConnectionCount { get; }
         public abstract int SendQueueLength { get; }
         public abstract int ReceiveQueueLength { get; }
+        public int BuffersInUse => this.bufferPool.NumberInUse;
 
-        protected ObjectPool<SmartBuffer> bufferPool;
+        protected readonly ObjectPool<SmartBuffer> bufferPool;
 
         public ConnectionListener()
         {

--- a/Hazel/Dtls/DtlsConnectionListener.cs
+++ b/Hazel/Dtls/DtlsConnectionListener.cs
@@ -1293,10 +1293,11 @@ namespace Hazel.Dtls
         /// </summary>
         protected override void QueueRawData(SmartBuffer span, IPEndPoint remoteEndPoint)
         {
-            PeerData peer;
-            if (!this.existingPeers.TryGetValue(remoteEndPoint, out peer))
+            span.AddUsage();
+            if (!this.existingPeers.TryGetValue(remoteEndPoint, out PeerData peer))
             {
                 // Drop messages if we don't know how to send them
+                span.Recycle();
                 return;
             }
 
@@ -1343,6 +1344,7 @@ namespace Hazel.Dtls
                     queuedSpan.Recycle();
                     base.QueueRawData(buffer, remoteEndPoint);
                 }
+
                 peer.QueuedApplicationDataMessage.Clear();
 
                 {

--- a/Hazel/Dtls/DtlsConnectionListener.cs
+++ b/Hazel/Dtls/DtlsConnectionListener.cs
@@ -708,68 +708,7 @@ namespace Hazel.Dtls
                             return false;
                         }
 
-                        ProtocolVersion protocolVersion = peer.ProtocolVersion;
-
-                        // Describe our ChangeCipherSpec+Finished
-                        Handshake outgoingHandshake = new Handshake();
-                        outgoingHandshake.MessageType = HandshakeType.Finished;
-                        outgoingHandshake.Length = Finished.Size;
-                        outgoingHandshake.MessageSequence = 7;
-                        outgoingHandshake.FragmentOffset = 0;
-                        outgoingHandshake.FragmentLength = outgoingHandshake.Length;
-
-                        Record changeCipherSpecRecord = new Record();
-                        changeCipherSpecRecord.ContentType = ContentType.ChangeCipherSpec;
-                        changeCipherSpecRecord.ProtocolVersion = protocolVersion;
-                        changeCipherSpecRecord.Epoch = (ushort)(peer.Epoch - 1);
-                        changeCipherSpecRecord.SequenceNumber = peer.CurrentEpoch.NextOutgoingSequenceForPreviousEpoch;
-                        changeCipherSpecRecord.Length = (ushort)peer.CurrentEpoch.PreviousRecordProtection.GetEncryptedSize(ChangeCipherSpec.Size);
-                        ++peer.CurrentEpoch.NextOutgoingSequenceForPreviousEpoch;
-
-                        int plaintextFinishedPayloadSize = Handshake.Size + (int)outgoingHandshake.Length;
-                        Record finishedRecord = new Record();
-                        finishedRecord.ContentType = ContentType.Handshake;
-                        finishedRecord.ProtocolVersion = protocolVersion;
-                        finishedRecord.Epoch = peer.Epoch;
-                        finishedRecord.SequenceNumber = peer.CurrentEpoch.NextOutgoingSequence;
-                        finishedRecord.Length = (ushort)peer.CurrentEpoch.RecordProtection.GetEncryptedSize(plaintextFinishedPayloadSize);
-                        ++peer.CurrentEpoch.NextOutgoingSequence;
-
-                        // Encode the flight into wire format
-                        SmartBuffer buffer = this.bufferPool.GetObject();
-                        buffer.Length = Record.Size + changeCipherSpecRecord.Length + Record.Size + finishedRecord.Length;
-                        packet = (ByteSpan)buffer;
-                        writer = packet;
-                        changeCipherSpecRecord.Encode(writer);
-                        writer = writer.Slice(Record.Size);
-                        ChangeCipherSpec.Encode(writer);
-
-                        ByteSpan startOfFinishedRecord = packet.Slice(Record.Size + changeCipherSpecRecord.Length);
-                        writer = startOfFinishedRecord;
-                        finishedRecord.Encode(writer);
-                        writer = writer.Slice(Record.Size);
-                        outgoingHandshake.Encode(writer);
-                        writer = writer.Slice(Handshake.Size);
-                        peer.CurrentEpoch.ServerFinishedVerification.CopyTo(writer);
-
-                        // Protect the ChangeChipherSpec record
-                        peer.CurrentEpoch.PreviousRecordProtection.EncryptServerPlaintext(
-                            packet.Slice(Record.Size, changeCipherSpecRecord.Length),
-                            packet.Slice(Record.Size, ChangeCipherSpec.Size),
-                            ref changeCipherSpecRecord
-                        );
-
-                        // Protect the Finished Handshake record
-                        peer.CurrentEpoch.RecordProtection.EncryptServerPlaintext(
-                            startOfFinishedRecord.Slice(Record.Size, finishedRecord.Length),
-                            startOfFinishedRecord.Slice(Record.Size, plaintextFinishedPayloadSize),
-                            ref finishedRecord
-                        );
-
-                        // Current epoch can now handle application data
-                        peer.CanHandleApplicationData = true;
-
-                        base.QueueRawData(buffer, peerAddress);
+                        SendFinishedHandshake(peer, peerAddress);
                         break;
 
                     // Drop messages that we do not support
@@ -791,6 +730,72 @@ namespace Hazel.Dtls
             }
 
             return true;
+        }
+
+        private void SendFinishedHandshake(PeerData peer, IPEndPoint peerAddress)
+        {
+            ProtocolVersion protocolVersion = peer.ProtocolVersion;
+
+            // Describe our ChangeCipherSpec+Finished
+            Handshake outgoingHandshake = new Handshake();
+            outgoingHandshake.MessageType = HandshakeType.Finished;
+            outgoingHandshake.Length = Finished.Size;
+            outgoingHandshake.MessageSequence = 7;
+            outgoingHandshake.FragmentOffset = 0;
+            outgoingHandshake.FragmentLength = outgoingHandshake.Length;
+
+            Record changeCipherSpecRecord = new Record();
+            changeCipherSpecRecord.ContentType = ContentType.ChangeCipherSpec;
+            changeCipherSpecRecord.ProtocolVersion = protocolVersion;
+            changeCipherSpecRecord.Epoch = (ushort)(peer.Epoch - 1);
+            changeCipherSpecRecord.SequenceNumber = peer.CurrentEpoch.NextOutgoingSequenceForPreviousEpoch;
+            changeCipherSpecRecord.Length = (ushort)peer.CurrentEpoch.PreviousRecordProtection.GetEncryptedSize(ChangeCipherSpec.Size);
+            ++peer.CurrentEpoch.NextOutgoingSequenceForPreviousEpoch;
+
+            int plaintextFinishedPayloadSize = Handshake.Size + (int)outgoingHandshake.Length;
+            Record finishedRecord = new Record();
+            finishedRecord.ContentType = ContentType.Handshake;
+            finishedRecord.ProtocolVersion = protocolVersion;
+            finishedRecord.Epoch = peer.Epoch;
+            finishedRecord.SequenceNumber = peer.CurrentEpoch.NextOutgoingSequence;
+            finishedRecord.Length = (ushort)peer.CurrentEpoch.RecordProtection.GetEncryptedSize(plaintextFinishedPayloadSize);
+            ++peer.CurrentEpoch.NextOutgoingSequence;
+
+            // Encode the flight into wire format
+            using SmartBuffer buffer = this.bufferPool.GetObject();
+            buffer.Length = Record.Size + changeCipherSpecRecord.Length + Record.Size + finishedRecord.Length;
+            ByteSpan packet = (ByteSpan)buffer;
+            ByteSpan writer = packet;
+            changeCipherSpecRecord.Encode(writer);
+            writer = writer.Slice(Record.Size);
+            ChangeCipherSpec.Encode(writer);
+
+            ByteSpan startOfFinishedRecord = packet.Slice(Record.Size + changeCipherSpecRecord.Length);
+            writer = startOfFinishedRecord;
+            finishedRecord.Encode(writer);
+            writer = writer.Slice(Record.Size);
+            outgoingHandshake.Encode(writer);
+            writer = writer.Slice(Handshake.Size);
+            peer.CurrentEpoch.ServerFinishedVerification.CopyTo(writer);
+
+            // Protect the ChangeChipherSpec record
+            peer.CurrentEpoch.PreviousRecordProtection.EncryptServerPlaintext(
+                packet.Slice(Record.Size, changeCipherSpecRecord.Length),
+                packet.Slice(Record.Size, ChangeCipherSpec.Size),
+                ref changeCipherSpecRecord
+            );
+
+            // Protect the Finished Handshake record
+            peer.CurrentEpoch.RecordProtection.EncryptServerPlaintext(
+                startOfFinishedRecord.Slice(Record.Size, finishedRecord.Length),
+                startOfFinishedRecord.Slice(Record.Size, plaintextFinishedPayloadSize),
+                ref finishedRecord
+            );
+
+            // Current epoch can now handle application data
+            peer.CanHandleApplicationData = true;
+
+            base.QueueRawData(buffer, peerAddress);
         }
 
         /// <summary>
@@ -998,9 +1003,10 @@ namespace Hazel.Dtls
 
             // Convert initial record of the flight to
             // wire format
-            SmartBuffer buffer = this.bufferPool.GetObject();
-            buffer.Length = Record.Size + initialRecord.Length;
-            ByteSpan packet = (ByteSpan)buffer;
+
+            using SmartBuffer initialBuffer = this.bufferPool.GetObject();
+            initialBuffer.Length = Record.Size + initialRecord.Length;
+            ByteSpan packet = (ByteSpan)initialBuffer;
             ByteSpan writer = packet;
             initialRecord.Encode(writer);
             writer = writer.Slice(Record.Size);
@@ -1020,7 +1026,7 @@ namespace Hazel.Dtls
                 ref initialRecord
             );
 
-            base.QueueRawData(buffer, peerAddress);
+            base.QueueRawData(initialBuffer, peerAddress);
 
             // Record record payload for verification
             if (recordMessagesForVerifyData)
@@ -1063,9 +1069,9 @@ namespace Hazel.Dtls
                 ++peer.CurrentEpoch.NextOutgoingSequence;
 
                 // Convert record to wire format
-                buffer = this.bufferPool.GetObject();
-                buffer.Length = Record.Size + additionalRecord.Length;
-                packet = (ByteSpan)buffer;
+                using SmartBuffer certBuffer = this.bufferPool.GetObject();
+                certBuffer.Length = Record.Size + additionalRecord.Length;
+                packet = (ByteSpan)certBuffer;
                 writer = packet;
                 additionalRecord.Encode(writer);
                 writer = writer.Slice(Record.Size);
@@ -1082,7 +1088,7 @@ namespace Hazel.Dtls
                     ref additionalRecord
                 );
 
-                base.QueueRawData(buffer, peerAddress);
+                base.QueueRawData(certBuffer, peerAddress);
             }
 
             // Describe final record of the flight
@@ -1114,9 +1120,9 @@ namespace Hazel.Dtls
 
             // Convert final record of the flight to wire
             // format
-            buffer = this.bufferPool.GetObject();
-            buffer.Length = Record.Size + finalRecord.Length;
-            packet = (ByteSpan)buffer;
+            using SmartBuffer finalBuffer = this.bufferPool.GetObject();
+            finalBuffer.Length = Record.Size + finalRecord.Length;
+            packet = (ByteSpan)finalBuffer;
             writer = packet;
             finalRecord.Encode(writer);
             writer = writer.Slice(Record.Size);
@@ -1144,7 +1150,7 @@ namespace Hazel.Dtls
                 ref finalRecord
             );
 
-            base.QueueRawData(buffer, peerAddress);
+            base.QueueRawData(finalBuffer, peerAddress);
 
             return true;
         }
@@ -1268,7 +1274,7 @@ namespace Hazel.Dtls
             record.Length = (ushort)recordProtection.GetEncryptedSize(plaintextPayloadSize);
 
             // Encode record to wire format
-            SmartBuffer buffer = this.bufferPool.GetObject();
+            using SmartBuffer buffer = this.bufferPool.GetObject();
             buffer.Length = Record.Size + record.Length;
             ByteSpan packet = (ByteSpan)buffer;
             ByteSpan writer = packet;
@@ -1293,11 +1299,8 @@ namespace Hazel.Dtls
         /// </summary>
         protected override void QueueRawData(SmartBuffer span, IPEndPoint remoteEndPoint)
         {
-            span.AddUsage();
             if (!this.existingPeers.TryGetValue(remoteEndPoint, out PeerData peer))
             {
-                // Drop messages if we don't know how to send them
-                span.Recycle();
                 return;
             }
 
@@ -1306,6 +1309,7 @@ namespace Hazel.Dtls
                 // If we're negotiating a new epoch, queue data
                 if (peer.Epoch == 0 || peer.NextEpoch.State != HandshakeState.ExpectingHello)
                 {
+                    span.AddUsage();
                     peer.QueuedApplicationDataMessage.Add(span);
                     return;
                 }
@@ -1315,7 +1319,7 @@ namespace Hazel.Dtls
                 // Send any queued application data now
                 for (int ii = 0, nn = peer.QueuedApplicationDataMessage.Count; ii != nn; ++ii)
                 {
-                    SmartBuffer queuedSpan = peer.QueuedApplicationDataMessage[ii];
+                    using SmartBuffer queuedSpan = peer.QueuedApplicationDataMessage[ii];
 
                     Record outgoingRecord = new Record();
                     outgoingRecord.ContentType = ContentType.ApplicationData;
@@ -1326,7 +1330,7 @@ namespace Hazel.Dtls
                     ++peer.CurrentEpoch.NextOutgoingSequence;
 
                     // Encode the record to wire format
-                    SmartBuffer buffer = this.bufferPool.GetObject();
+                    using SmartBuffer buffer = this.bufferPool.GetObject();
                     buffer.Length = Record.Size + outgoingRecord.Length;
                     ByteSpan packet = (ByteSpan)buffer;
                     ByteSpan writer = packet;
@@ -1341,7 +1345,6 @@ namespace Hazel.Dtls
                         ref outgoingRecord
                     );
 
-                    queuedSpan.Recycle();
                     base.QueueRawData(buffer, remoteEndPoint);
                 }
 
@@ -1357,7 +1360,7 @@ namespace Hazel.Dtls
                     ++peer.CurrentEpoch.NextOutgoingSequence;
 
                     // Encode the record to wire format
-                    SmartBuffer buffer = this.bufferPool.GetObject();
+                    using SmartBuffer buffer = this.bufferPool.GetObject();
                     buffer.Length = Record.Size + outgoingRecord.Length;
                     ByteSpan packet = (ByteSpan)buffer;
                     ByteSpan writer = packet;
@@ -1372,7 +1375,6 @@ namespace Hazel.Dtls
                         ref outgoingRecord
                     );
 
-                    span.Recycle();
                     base.QueueRawData(buffer, remoteEndPoint);
                 }
             }

--- a/Hazel/Dtls/DtlsUnityConnection.cs
+++ b/Hazel/Dtls/DtlsUnityConnection.cs
@@ -354,29 +354,23 @@ namespace Hazel.Dtls
         /// <inheritdoc />
         protected override void WriteBytesToConnection(SmartBuffer bytes, int length)
         {
-            SmartBuffer wireData = this.WriteBytesToConnectionInternal(bytes, length);
-            bytes.Recycle();
-            wireData.AddUsage();
+            using SmartBuffer wireData = this.WriteBytesToConnectionInternal(bytes, length);
+            
             if (wireData.Length > 0)
             {
                 base.WriteBytesToConnection(wireData, wireData.Length);
             }
-
-            wireData.Recycle();
         }
 
         /// <inheritdoc />
         protected override void WriteBytesToConnectionSync(SmartBuffer bytes, int length)
         {
-            SmartBuffer wireData = this.WriteBytesToConnectionInternal(bytes, length);
-            bytes.Recycle();
-            wireData.AddUsage();
+            using SmartBuffer wireData = this.WriteBytesToConnectionInternal(bytes, length);
+            
             if (wireData.Length > 0)
             {
                 base.WriteBytesToConnectionSync(wireData, wireData.Length);
             }
-
-            wireData.Recycle();
         }
 
         /// <inheritdoc />
@@ -996,7 +990,7 @@ namespace Hazel.Dtls
             ++this.currentEpoch.NextOutgoingSequence;
 
             // Convert the record to wire format
-            SmartBuffer buffer = this.bufferPool.GetObject();
+            using SmartBuffer buffer = this.bufferPool.GetObject();
             buffer.Length = Record.Size + outgoingRecord.Length;
             ByteSpan packet = (ByteSpan)buffer;
             ByteSpan writer = packet;
@@ -1069,7 +1063,7 @@ namespace Hazel.Dtls
             ++this.currentEpoch.NextOutgoingSequence;
 
             // Convert the record to wire format
-            SmartBuffer buffer = this.bufferPool.GetObject();
+            using SmartBuffer buffer = this.bufferPool.GetObject();
             buffer.Length = Record.Size + outgoingRecord.Length;
             ByteSpan packet = (ByteSpan)buffer;
             ByteSpan writer = packet;
@@ -1165,7 +1159,7 @@ namespace Hazel.Dtls
                 + Record.Size + finishedRecord.Length;
                 ;
 
-            SmartBuffer buffer = this.bufferPool.GetObject();
+            using SmartBuffer buffer = this.bufferPool.GetObject();
             buffer.Length = packetLength;
             ByteSpan packet = (ByteSpan)buffer;
             ByteSpan writer = packet;

--- a/Hazel/Dtls/DtlsUnityConnection.cs
+++ b/Hazel/Dtls/DtlsUnityConnection.cs
@@ -297,7 +297,7 @@ namespace Hazel.Dtls
         /// Encrypted data to put on the wire if appropriate,
         /// otherwise an empty span
         /// </returns>
-        private ByteSpan WriteBytesToConnectionInternal(byte[] bytes, int length)
+        private SmartBuffer WriteBytesToConnectionInternal(SmartBuffer bytes, int length)
         {
             lock (this.syncRoot)
             {
@@ -310,11 +310,14 @@ namespace Hazel.Dtls
                 ++this.currentEpoch.NextOutgoingSequence;
 
                 // Encode the record to wire format
-                ByteSpan packet = new byte[Record.Size + outgoinRecord.Length];
+                SmartBuffer buffer = this.bufferPool.GetObject();
+
+                buffer.Length = Record.Size + outgoinRecord.Length;
+                ByteSpan packet = (ByteSpan)buffer;
                 ByteSpan writer = packet;
                 outgoinRecord.Encode(writer);
                 writer = writer.Slice(Record.Size);
-                new ByteSpan(bytes, 0, length).CopyTo(writer);
+                new ByteSpan((byte[])bytes, 0, length).CopyTo(writer);
 
                 // Protect the record
                 this.currentEpoch.RecordProtection.EncryptClientPlaintext(
@@ -323,7 +326,7 @@ namespace Hazel.Dtls
                     ref outgoinRecord
                 );
 
-                return packet;
+                return buffer;
             }
         }
 
@@ -349,25 +352,31 @@ namespace Hazel.Dtls
         }
 
         /// <inheritdoc />
-        protected override void WriteBytesToConnection(byte[] bytes, int length)
+        protected override void WriteBytesToConnection(SmartBuffer bytes, int length)
         {
-            ByteSpan wireData = this.WriteBytesToConnectionInternal(bytes, length);
+            SmartBuffer wireData = this.WriteBytesToConnectionInternal(bytes, length);
+            bytes.Recycle();
+            wireData.AddUsage();
             if (wireData.Length > 0)
             {
-                Debug.Assert(wireData.Offset == 0, "Got a non-zero write data offset");
-                base.WriteBytesToConnection(wireData.GetUnderlyingArray(), wireData.Length);
+                base.WriteBytesToConnection(wireData, wireData.Length);
             }
+
+            wireData.Recycle();
         }
 
         /// <inheritdoc />
-        protected override void WriteBytesToConnectionSync(byte[] bytes, int length)
+        protected override void WriteBytesToConnectionSync(SmartBuffer bytes, int length)
         {
-            ByteSpan wireData = this.WriteBytesToConnectionInternal(bytes, length);
+            SmartBuffer wireData = this.WriteBytesToConnectionInternal(bytes, length);
+            bytes.Recycle();
+            wireData.AddUsage();
             if (wireData.Length > 0)
             {
-                Debug.Assert(wireData.Offset == 0, "Got a non-zero write data offset");
-                base.WriteBytesToConnectionSync(wireData.GetUnderlyingArray(), wireData.Length);
+                base.WriteBytesToConnectionSync(wireData, wireData.Length);
             }
+
+            wireData.Recycle();
         }
 
         /// <inheritdoc />
@@ -987,7 +996,9 @@ namespace Hazel.Dtls
             ++this.currentEpoch.NextOutgoingSequence;
 
             // Convert the record to wire format
-            ByteSpan packet = new byte[Record.Size + outgoingRecord.Length];
+            SmartBuffer buffer = this.bufferPool.GetObject();
+            buffer.Length = Record.Size + outgoingRecord.Length;
+            ByteSpan packet = (ByteSpan)buffer;
             ByteSpan writer = packet;
             outgoingRecord.Encode(packet);
             writer = writer.Slice(Record.Size);
@@ -1023,7 +1034,7 @@ namespace Hazel.Dtls
             if (this.nextEpoch.NegotiationStartTime == DateTime.MinValue) this.nextEpoch.NegotiationStartTime = DateTime.UtcNow;
             this.nextEpoch.NextPacketResendTime = DateTime.UtcNow + this.handshakeResendTimeout;
 
-            base.WriteBytesToConnection(packet.GetUnderlyingArray(), packet.Length);
+            base.WriteBytesToConnection(buffer, packet.Length);
         }
 
         protected void Test_SendClientHello(Func<ClientHello, ByteSpan, ByteSpan> encodeCallback)
@@ -1058,7 +1069,9 @@ namespace Hazel.Dtls
             ++this.currentEpoch.NextOutgoingSequence;
 
             // Convert the record to wire format
-            ByteSpan packet = new byte[Record.Size + outgoingRecord.Length];
+            SmartBuffer buffer = this.bufferPool.GetObject();
+            buffer.Length = Record.Size + outgoingRecord.Length;
+            ByteSpan packet = (ByteSpan)buffer;
             ByteSpan writer = packet;
             outgoingRecord.Encode(packet);
             writer = writer.Slice(Record.Size);
@@ -1085,7 +1098,7 @@ namespace Hazel.Dtls
             this.nextEpoch.State = HandshakeState.ExpectingServerHello;
             if (this.nextEpoch.NegotiationStartTime == DateTime.MinValue) this.nextEpoch.NegotiationStartTime = DateTime.UtcNow;
             this.nextEpoch.NextPacketResendTime = DateTime.UtcNow + this.handshakeResendTimeout;
-            base.WriteBytesToConnection(packet.GetUnderlyingArray(), packet.Length);
+            base.WriteBytesToConnection(buffer, packet.Length);
         }
 
         /// <summary>
@@ -1151,7 +1164,10 @@ namespace Hazel.Dtls
                 + Record.Size + changeCipherSpecRecord.Length
                 + Record.Size + finishedRecord.Length;
                 ;
-            ByteSpan packet = new byte[packetLength];
+
+            SmartBuffer buffer = this.bufferPool.GetObject();
+            buffer.Length = packetLength;
+            ByteSpan packet = (ByteSpan)buffer;
             ByteSpan writer = packet;
 
             keyExchangeRecord.Encode(writer);
@@ -1235,7 +1251,7 @@ namespace Hazel.Dtls
                 return;
             }
 #endif
-            base.WriteBytesToConnection(packet.GetUnderlyingArray(), packet.Length);
+            base.WriteBytesToConnection(buffer, packet.Length);
         }
 
         protected virtual bool DropClientKeyExchangeFlight()

--- a/Hazel/FewerThreads/ThreadLimitedUdpConnectionListener.cs
+++ b/Hazel/FewerThreads/ThreadLimitedUdpConnectionListener.cs
@@ -246,10 +246,11 @@ namespace Hazel.Udp.FewerThreads
             {
                 try
                 {
+                    using var buffer = msg.Span;
                     if (this.socket.Poll(Timeout.Infinite, SelectMode.SelectWrite))
                     {
-                        this.socket.SendTo((byte[])msg.Span, 0, msg.Span.Length, SocketFlags.None, msg.Recipient);
-                        this.Statistics.AddBytesSent(msg.Span.Length);
+                        this.socket.SendTo((byte[])buffer, 0, buffer.Length, SocketFlags.None, msg.Recipient);
+                        this.Statistics.AddBytesSent(buffer.Length);
                     }
                     else
                     {
@@ -261,10 +262,6 @@ namespace Hazel.Udp.FewerThreads
                 {
                     this.Logger.WriteError("Error in loop while sending: " + e.Message);
                     Thread.Sleep(1);
-                }
-                finally
-                {
-                    msg.Span.Recycle();
                 }
             }
         }
@@ -298,7 +295,7 @@ namespace Hazel.Udp.FewerThreads
                                 message.Recycle();
                                 if (response != null)
                                 {
-                                    var buffer = this.bufferPool.GetObject();
+                                    using SmartBuffer buffer = this.bufferPool.GetObject();
                                     buffer.CopyFrom(response);
                                     SendDataRaw(buffer, remoteEndPoint);
                                 }

--- a/Hazel/FewerThreads/ThreadLimitedUdpServerConnection.cs
+++ b/Hazel/FewerThreads/ThreadLimitedUdpServerConnection.cs
@@ -78,7 +78,7 @@ namespace Hazel.Udp.FewerThreads
             if (!Listener.RemoveConnectionTo(this.ConnectionId)) return false;
             this._state = ConnectionState.NotConnected;
 
-            SmartBuffer buffer = this.bufferPool.GetObject();
+            using SmartBuffer buffer = this.bufferPool.GetObject();
             buffer.CopyFrom(EmptyDisconnectBytes);
             if (data != null && data.Length > 0)
             {

--- a/Hazel/Hazel.csproj
+++ b/Hazel/Hazel.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
+		<LangVersion>8.0</LangVersion>
         <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>

--- a/Hazel/SmartBuffer.cs
+++ b/Hazel/SmartBuffer.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Threading;
+
+namespace Hazel
+{
+    public class SmartBuffer : IRecyclable
+    {
+        private readonly ObjectPool<SmartBuffer> parent;
+
+        private byte[] buffer;
+        private int usageCount;
+
+        private int length;
+        public int Length
+        {
+            get => this.length;
+            set
+            {
+                this.length = value;
+
+                if (value > this.buffer.Length)
+                {
+                    this.buffer = new byte[value];
+                }
+            }
+        }
+
+        public SmartBuffer(ObjectPool<SmartBuffer> parent, int size)
+        {
+            this.parent = parent;
+            this.buffer = new byte[size];
+        }
+
+        public byte this[int i]
+        {
+            get => this.buffer[i];
+            set => this.buffer[i] = value;
+        }
+
+
+        public static explicit operator ByteSpan(SmartBuffer b)
+        {
+            return new ByteSpan(b.buffer, 0, b.length);
+        }
+
+        public static explicit operator byte[](SmartBuffer b)
+        {
+            return b.buffer;
+        }
+
+        public void AddUsage()
+        {
+            Interlocked.Increment(ref this.usageCount);
+        }
+
+        public void Recycle()
+        {
+            if (Interlocked.Decrement(ref this.usageCount) == 0)
+            {
+                parent.PutObject(this);
+            }
+        }
+
+        public void CopyFrom(byte[] bytes)
+        {
+            this.Length = bytes.Length;
+            Buffer.BlockCopy(bytes, 0, this.buffer, 0, bytes.Length);
+        }
+
+        public void CopyFrom(MessageWriter data)
+        {
+            this.Length = data.Length;
+            Buffer.BlockCopy(data.Buffer, 0, this.buffer, 0, data.Length);
+        }
+    }
+}

--- a/Hazel/Udp/UdpConnection.KeepAlive.cs
+++ b/Hazel/Udp/UdpConnection.KeepAlive.cs
@@ -111,26 +111,33 @@ namespace Hazel.Udp
         {
             ushort id = (ushort)Interlocked.Increment(ref lastIDAllocated);
 
-            byte[] bytes = new byte[3];
-            bytes[0] = (byte)UdpSendOption.Ping;
-            bytes[1] = (byte)(id >> 8);
-            bytes[2] = (byte)id;
+            var buffer = this.bufferPool.GetObject();
+            buffer.Length = 3;
+            buffer.AddUsage();
+            buffer[0] = (byte)UdpSendOption.Ping;
+            buffer[1] = (byte)(id >> 8);
+            buffer[2] = (byte)id;
 
-            PingPacket pkt;
-            if (!this.activePingPackets.TryGetValue(id, out pkt))
+            if (!this.activePingPackets.TryGetValue(id, out var ping))
             {
-                pkt = PingPacket.GetObject();
-                if (!this.activePingPackets.TryAdd(id, pkt))
+                ping = PingPacket.GetObject();
+                if (!this.activePingPackets.TryAdd(id, ping))
                 {
                     throw new Exception("This shouldn't be possible");
                 }
             }
 
-            pkt.Stopwatch.Restart();
+            ping.Stopwatch.Restart();
 
-            WriteBytesToConnection(bytes, bytes.Length);
-
-            Statistics.LogReliableSend(0);
+            try
+            {
+                WriteBytesToConnection(buffer, buffer.Length);
+                Statistics.LogReliableSend(0);
+            }
+            finally
+            {
+                buffer.Recycle();
+            }
         }
 
         /// <summary>

--- a/Hazel/Udp/UdpConnection.KeepAlive.cs
+++ b/Hazel/Udp/UdpConnection.KeepAlive.cs
@@ -111,9 +111,8 @@ namespace Hazel.Udp
         {
             ushort id = (ushort)Interlocked.Increment(ref lastIDAllocated);
 
-            var buffer = this.bufferPool.GetObject();
+            using SmartBuffer buffer = this.bufferPool.GetObject();
             buffer.Length = 3;
-            buffer.AddUsage();
             buffer[0] = (byte)UdpSendOption.Ping;
             buffer[1] = (byte)(id >> 8);
             buffer[2] = (byte)id;
@@ -129,15 +128,8 @@ namespace Hazel.Udp
 
             ping.Stopwatch.Restart();
 
-            try
-            {
-                WriteBytesToConnection(buffer, buffer.Length);
-                Statistics.LogReliableSend(0);
-            }
-            finally
-            {
-                buffer.Recycle();
-            }
+            WriteBytesToConnection(buffer, buffer.Length);
+            Statistics.LogReliableSend(0);
         }
 
         /// <summary>

--- a/Hazel/Udp/UdpConnection.Reliable.cs
+++ b/Hazel/Udp/UdpConnection.Reliable.cs
@@ -256,25 +256,16 @@ namespace Hazel.Udp
             // Inform keepalive not to send for a while
             ResetKeepAliveTimer();
 
-            SmartBuffer buffer = this.bufferPool.GetObject();
+            using SmartBuffer buffer = this.bufferPool.GetObject();
             buffer.Length = data.Length + 3;
-            buffer.AddUsage();
-
+            
             // Add message type, reliable id, and data
             buffer[0] = sendOption;
             AttachReliableID(buffer, 1, buffer.Length, ackCallback);
             Buffer.BlockCopy(data, 0, (byte[])buffer, 3, data.Length);
 
-            // Write to connection
-            try
-            {
-                WriteBytesToConnection(buffer, buffer.Length);
-                Statistics.LogReliableSend(data.Length);
-            }
-            finally
-            {
-                buffer.Recycle();
-            }
+            WriteBytesToConnection(buffer, buffer.Length);
+            Statistics.LogReliableSend(data.Length);
         }
 
         /// <summary>
@@ -467,9 +458,8 @@ namespace Hazel.Udp
                 }
             }
 
-            SmartBuffer buffer = this.bufferPool.GetObject();
+            using SmartBuffer buffer = this.bufferPool.GetObject();
             buffer.Length = 4;
-            buffer.AddUsage();
             buffer[0] = (byte)UdpSendOption.Acknowledgement;
             buffer[1] = (byte)(id >> 8);
             buffer[2] = (byte)(id >> 0);
@@ -480,10 +470,6 @@ namespace Hazel.Udp
                 WriteBytesToConnection(buffer, buffer.Length);
             }
             catch (InvalidOperationException) { }
-            finally
-            {
-                buffer.Recycle();
-            }
         }
 
         private void DisposeReliablePackets()

--- a/Hazel/Udp/UdpConnectionListener.cs
+++ b/Hazel/Udp/UdpConnectionListener.cs
@@ -193,12 +193,14 @@ namespace Hazel.Udp
 
                         if (AcceptConnection != null)
                         {
-                            if (!AcceptConnection((IPEndPoint)remoteEndPoint, message.Buffer, out var response))
+                            if (!AcceptConnection((IPEndPoint)remoteEndPoint, message.Buffer, out byte[] response))
                             {
                                 message.Recycle();
                                 if (response != null)
                                 {
-                                    SendData(response, response.Length, remoteEndPoint);
+                                    var buffer = this.bufferPool.GetObject();
+                                    buffer.CopyFrom(response);
+                                    SendData(buffer, buffer.Length, remoteEndPoint);
                                 }
 
                                 return;
@@ -241,9 +243,12 @@ namespace Hazel.Udp
         /// </summary>
         /// <param name="bytes">The bytes to send.</param>
         /// <param name="endPoint">The endpoint to send to.</param>
-        internal void SendData(byte[] bytes, int length, EndPoint endPoint)
+        internal void SendData(SmartBuffer bytes, int length, EndPoint endPoint)
         {
-            if (length > bytes.Length) return;
+            if (length > bytes.Length)
+            {
+                return;
+            }
 
 #if DEBUG
             if (TestDropRate > 0)
@@ -257,14 +262,15 @@ namespace Hazel.Udp
 
             try
             {
+                bytes.AddUsage();
                 socket.BeginSendTo(
-                    bytes,
+                    (byte[])bytes,
                     0,
                     length,
                     SocketFlags.None,
                     endPoint,
                     SendCallback,
-                    null);
+                    bytes);
 
                 this.Statistics.AddBytesSent(length);
             }
@@ -286,6 +292,10 @@ namespace Hazel.Udp
                 socket.EndSendTo(result);
             }
             catch { }
+            finally
+            {
+                ((SmartBuffer)result.AsyncState).Recycle();
+            }
         }
 
         /// <summary>

--- a/Hazel/Udp/UdpConnectionListener.cs
+++ b/Hazel/Udp/UdpConnectionListener.cs
@@ -198,7 +198,7 @@ namespace Hazel.Udp
                                 message.Recycle();
                                 if (response != null)
                                 {
-                                    var buffer = this.bufferPool.GetObject();
+                                    using SmartBuffer buffer = this.bufferPool.GetObject();
                                     buffer.CopyFrom(response);
                                     SendData(buffer, buffer.Length, remoteEndPoint);
                                 }

--- a/Hazel/Udp/UdpServerConnection.cs
+++ b/Hazel/Udp/UdpServerConnection.cs
@@ -36,7 +36,7 @@ namespace Hazel.Udp
         }
 
         /// <inheritdoc />
-        protected override void WriteBytesToConnection(byte[] bytes, int length)
+        protected override void WriteBytesToConnection(SmartBuffer bytes, int length)
         {
             this.Statistics.LogPacketSend(length);
             Listener.SendData(bytes, length, EndPoint);

--- a/Hazel/Udp/UnityUdpClientConnection.cs
+++ b/Hazel/Udp/UnityUdpClientConnection.cs
@@ -100,13 +100,18 @@ namespace Hazel.Udp
                     HandleSendTo,
                     bytes);
             }
-            catch (NullReferenceException) { }
+            catch (NullReferenceException)
+            {
+                bytes.Recycle();
+            }
             catch (ObjectDisposedException)
             {
                 // Already disposed and disconnected...
+                bytes.Recycle();
             }
             catch (SocketException ex)
             {
+                bytes.Recycle();
                 DisconnectInternal(HazelInternalErrors.SocketExceptionSend, "Could not send data as a SocketException occurred: " + ex.Message);
             }
         }
@@ -327,7 +332,7 @@ namespace Hazel.Udp
                 this._state = ConnectionState.NotConnected;
             }
 
-            SmartBuffer buffer = this.bufferPool.GetObject();
+            using SmartBuffer buffer = this.bufferPool.GetObject();
             buffer.CopyFrom(EmptyDisconnectBytes);
 
             if (data != null && data.Length > 0)

--- a/Hazel/Udp/UnityUdpClientConnection.cs
+++ b/Hazel/Udp/UnityUdpClientConnection.cs
@@ -71,7 +71,7 @@ namespace Hazel.Udp
         }
 
         /// <inheritdoc />
-        protected override void WriteBytesToConnection(byte[] bytes, int length)
+        protected override void WriteBytesToConnection(SmartBuffer bytes, int length)
         {
 #if DEBUG
             if (TestLagMs > 0)
@@ -85,19 +85,20 @@ namespace Hazel.Udp
             }
         }
 
-        private void WriteBytesToConnectionReal(byte[] bytes, int length)
+        private void WriteBytesToConnectionReal(SmartBuffer bytes, int length)
         {
             try
             {
+                bytes.AddUsage();
                 this.Statistics.LogPacketSend(length);
                 socket.BeginSendTo(
-                    bytes,
+                    (byte[])bytes,
                     0,
                     length,
                     SocketFlags.None,
                     EndPoint,
                     HandleSendTo,
-                    null);
+                    bytes);
             }
             catch (NullReferenceException) { }
             catch (ObjectDisposedException)
@@ -114,12 +115,13 @@ namespace Hazel.Udp
         ///     Synchronously writes the given bytes to the connection.
         /// </summary>
         /// <param name="bytes">The bytes to write.</param>
-        protected virtual void WriteBytesToConnectionSync(byte[] bytes, int length)
+        protected virtual void WriteBytesToConnectionSync(SmartBuffer bytes, int length)
         {
+            bytes.AddUsage();
             try
             {
                 socket.SendTo(
-                    bytes,
+                    (byte[])bytes,
                     0,
                     length,
                     SocketFlags.None,
@@ -133,6 +135,10 @@ namespace Hazel.Udp
             catch (SocketException ex)
             {
                 DisconnectInternal(HazelInternalErrors.SocketExceptionSend, "Could not send data as a SocketException occurred: " + ex.Message);
+            }
+            finally
+            {
+                bytes.Recycle();
             }
         }
 
@@ -150,6 +156,10 @@ namespace Hazel.Udp
             catch (SocketException ex)
             {
                 DisconnectInternal(HazelInternalErrors.SocketExceptionSend, "Could not send data as a SocketException occurred: " + ex.Message);
+            }
+            finally
+            {
+                ((SmartBuffer)result.AsyncState).Recycle();
             }
         }
 
@@ -317,18 +327,20 @@ namespace Hazel.Udp
                 this._state = ConnectionState.NotConnected;
             }
 
-            var bytes = EmptyDisconnectBytes;
+            SmartBuffer buffer = this.bufferPool.GetObject();
+            buffer.CopyFrom(EmptyDisconnectBytes);
+
             if (data != null && data.Length > 0)
             {
                 if (data.SendOption != SendOption.None) throw new ArgumentException("Disconnect messages can only be unreliable.");
 
-                bytes = data.ToByteArray(true);
-                bytes[0] = (byte)UdpSendOption.Disconnect;
+                buffer.CopyFrom(data);
+                buffer[0] = (byte)UdpSendOption.Disconnect;
             }
 
             try
             {
-                this.WriteBytesToConnectionSync(bytes, bytes.Length);
+                this.WriteBytesToConnectionSync(buffer, buffer.Length);
             }
             catch { }
 


### PR DESCRIPTION
Been thinking about them allocations lately...

Sucks that we make a bunch of new `byte[]` every time we do a send. But it's also annoying to have to deal with threaded reliable resends making buffer lifetimes racy.

So I reinvented Smart Pointers and it seems like it works pretty well.

Edit: To avoid confusion:
AddUsage is to be used right before a SmartBuffer needs to be preserved for some reason. This only happens in a few places: As we enqueue data for later, as we store data for resending, and as we call BeginSendTo.
Nearly all usages of SmartBuffer don't need AddUsage or Recycle. A simple `using` statement wraps that up so we can never fail to recycle.