### PR TITLE
Reduce allocations and optimize out method calls during encryption

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.user
 *.sln.docstates
 .vs/
+.idea/
 
 # Build results
 [Dd]ebug/

--- a/Hazel.UnitTests/Dtls/AesGcmRecordProtectedTests.cs
+++ b/Hazel.UnitTests/Dtls/AesGcmRecordProtectedTests.cs
@@ -8,6 +8,7 @@ namespace Hazel.UnitTests.Dtls
     [TestClass]
     public class AesGcmRecordProtectedTests
     {
+        private readonly ObjectPool<SmartBuffer> bufferPool;
         private readonly ByteSpan masterSecret;
         private readonly ByteSpan serverRandom;
         private readonly ByteSpan clientRandom;
@@ -16,6 +17,7 @@ namespace Hazel.UnitTests.Dtls
 
         public AesGcmRecordProtectedTests()
         {
+            this.bufferPool = new ObjectPool<SmartBuffer>(() => new SmartBuffer(this.bufferPool, 1024));
             this.masterSecret = new byte[48];
             this.serverRandom = new byte[32];
             this.clientRandom = new byte[32];
@@ -31,7 +33,7 @@ namespace Hazel.UnitTests.Dtls
         [TestMethod]
         public void ServerCanEncryptAndDecryptData()
         {
-            using (Aes128GcmRecordProtection recordProtection = new Aes128GcmRecordProtection(this.masterSecret, this.serverRandom, this.clientRandom))
+            using (Aes128GcmRecordProtection recordProtection = new Aes128GcmRecordProtection(this.bufferPool, this.masterSecret, this.serverRandom, this.clientRandom))
             {
                 byte[] messageAsBytes = Encoding.UTF8.GetBytes(TestMessage);
 
@@ -56,7 +58,7 @@ namespace Hazel.UnitTests.Dtls
         [TestMethod]
         public void ClientCanEncryptAndDecryptData()
         {
-            using (Aes128GcmRecordProtection recordProtection = new Aes128GcmRecordProtection(this.masterSecret, this.serverRandom, this.clientRandom))
+            using (Aes128GcmRecordProtection recordProtection = new Aes128GcmRecordProtection(this.bufferPool, this.masterSecret, this.serverRandom, this.clientRandom))
             {
                 byte[] messageAsBytes = Encoding.UTF8.GetBytes(TestMessage);
 
@@ -81,7 +83,7 @@ namespace Hazel.UnitTests.Dtls
         [TestMethod]
         public void ServerDecryptionFailsWhenRecordModified()
         {
-            using (Aes128GcmRecordProtection recordProtection = new Aes128GcmRecordProtection(this.masterSecret, this.serverRandom, this.clientRandom))
+            using (Aes128GcmRecordProtection recordProtection = new Aes128GcmRecordProtection(this.bufferPool, this.masterSecret, this.serverRandom, this.clientRandom))
             {
                 byte[] messageAsBytes = Encoding.UTF8.GetBytes(TestMessage);
 
@@ -117,7 +119,7 @@ namespace Hazel.UnitTests.Dtls
         [TestMethod]
         public void ClientDecryptionFailsWhenRecordModified()
         {
-            using (Aes128GcmRecordProtection recordProtection = new Aes128GcmRecordProtection(this.masterSecret, this.serverRandom, this.clientRandom))
+            using (Aes128GcmRecordProtection recordProtection = new Aes128GcmRecordProtection(this.bufferPool, this.masterSecret, this.serverRandom, this.clientRandom))
             {
                 byte[] messageAsBytes = Encoding.UTF8.GetBytes(TestMessage);
 
@@ -153,7 +155,7 @@ namespace Hazel.UnitTests.Dtls
         [TestMethod]
         public void ServerEncryptionCanoverlap()
         {
-            using (Aes128GcmRecordProtection recordProtection = new Aes128GcmRecordProtection(this.masterSecret, this.serverRandom, this.clientRandom))
+            using (Aes128GcmRecordProtection recordProtection = new Aes128GcmRecordProtection(this.bufferPool, this.masterSecret, this.serverRandom, this.clientRandom))
             {
                 ByteSpan messageAsBytes = Encoding.UTF8.GetBytes(TestMessage);
 
@@ -179,7 +181,7 @@ namespace Hazel.UnitTests.Dtls
         [TestMethod]
         public void ClientEncryptionCanoverlap()
         {
-            using (Aes128GcmRecordProtection recordProtection = new Aes128GcmRecordProtection(this.masterSecret, this.serverRandom, this.clientRandom))
+            using (Aes128GcmRecordProtection recordProtection = new Aes128GcmRecordProtection(this.bufferPool, this.masterSecret, this.serverRandom, this.clientRandom))
             {
                 ByteSpan messageAsBytes = Encoding.UTF8.GetBytes(TestMessage);
 

--- a/Hazel.UnitTests/Dtls/X25519EcdheRsaSha256Tests.cs
+++ b/Hazel.UnitTests/Dtls/X25519EcdheRsaSha256Tests.cs
@@ -10,12 +10,14 @@ namespace Hazel.UnitTests.Dtls
         private readonly RandomNumberGenerator random = RandomNumberGenerator.Create();
         private readonly RSA privateKey = RSA.Create();
         private readonly RSA publicKey;
+        private readonly ObjectPool<SmartBuffer> bufferPool;
 
         public X25519EcdheRsaSha256Tests()
         {
             RSAParameters keyParameters = this.privateKey.ExportParameters(false);
             this.publicKey = RSA.Create();
             this.publicKey.ImportParameters(keyParameters);
+            this.bufferPool = new ObjectPool<SmartBuffer>(() => new SmartBuffer(this.bufferPool, 1024));
         }
 
         [TestMethod]
@@ -23,7 +25,7 @@ namespace Hazel.UnitTests.Dtls
         {
             byte[] data;
 
-            using (X25519EcdheRsaSha256 cipherSuite = new X25519EcdheRsaSha256(this.random))
+            using (X25519EcdheRsaSha256 cipherSuite = new X25519EcdheRsaSha256(this.bufferPool, this.random))
             {
                 int expectedSize = cipherSuite.CalculateServerMessageSize(this.privateKey);
                 Assert.IsTrue(expectedSize/2 > 1);
@@ -32,7 +34,7 @@ namespace Hazel.UnitTests.Dtls
                 random.GetBytes(data);
             }
 
-            using (X25519EcdheRsaSha256 cipherSuite = new X25519EcdheRsaSha256(this.random))
+            using (X25519EcdheRsaSha256 cipherSuite = new X25519EcdheRsaSha256(this.bufferPool, this.random))
             {
                 byte[] sharedKey = new byte[cipherSuite.SharedKeySize()];
                 Assert.IsFalse(cipherSuite.VerifyServerMessageAndGenerateSharedKey(sharedKey, data, this.publicKey));
@@ -44,7 +46,7 @@ namespace Hazel.UnitTests.Dtls
         {
             byte[] data;
 
-            using (X25519EcdheRsaSha256 cipherSuite = new X25519EcdheRsaSha256(this.random))
+            using (X25519EcdheRsaSha256 cipherSuite = new X25519EcdheRsaSha256(this.bufferPool, this.random))
             {
                 int expectedSize = cipherSuite.CalculateServerMessageSize(this.privateKey);
                 Assert.IsTrue(expectedSize > 0);
@@ -53,7 +55,7 @@ namespace Hazel.UnitTests.Dtls
                 random.GetBytes(data);
             }
 
-            using (X25519EcdheRsaSha256 cipherSuite = new X25519EcdheRsaSha256(this.random))
+            using (X25519EcdheRsaSha256 cipherSuite = new X25519EcdheRsaSha256(this.bufferPool, this.random))
             {
                 byte[] sharedKey = new byte[cipherSuite.SharedKeySize()];
                 Assert.IsFalse(cipherSuite.VerifyServerMessageAndGenerateSharedKey(sharedKey, data, this.publicKey));
@@ -65,7 +67,7 @@ namespace Hazel.UnitTests.Dtls
         {
             byte[] data;
 
-            using (X25519EcdheRsaSha256 cipherSuite = new X25519EcdheRsaSha256(this.random))
+            using (X25519EcdheRsaSha256 cipherSuite = new X25519EcdheRsaSha256(this.bufferPool, this.random))
             {
                 int expectedSize = cipherSuite.CalculateServerMessageSize(this.privateKey);
                 Assert.IsTrue(expectedSize > 0);
@@ -74,7 +76,7 @@ namespace Hazel.UnitTests.Dtls
                 random.GetBytes(data);
             }
 
-            using (X25519EcdheRsaSha256 cipherSuite = new X25519EcdheRsaSha256(this.random))
+            using (X25519EcdheRsaSha256 cipherSuite = new X25519EcdheRsaSha256(this.bufferPool, this.random))
             {
                 byte[] sharedKey = new byte[cipherSuite.SharedKeySize()];
                 Assert.IsFalse(cipherSuite.VerifyServerMessageAndGenerateSharedKey(sharedKey, data, this.publicKey));
@@ -86,7 +88,7 @@ namespace Hazel.UnitTests.Dtls
         {
             byte[] data;
 
-            using (X25519EcdheRsaSha256 cipherSuite = new X25519EcdheRsaSha256(this.random))
+            using (X25519EcdheRsaSha256 cipherSuite = new X25519EcdheRsaSha256(this.bufferPool, this.random))
             {
                 int expectedSize = cipherSuite.CalculateClientMessageSize();
                 Assert.IsTrue(expectedSize / 2 > 1);
@@ -95,7 +97,7 @@ namespace Hazel.UnitTests.Dtls
                 random.GetBytes(data);
             }
 
-            using (X25519EcdheRsaSha256 cipherSuite = new X25519EcdheRsaSha256(this.random))
+            using (X25519EcdheRsaSha256 cipherSuite = new X25519EcdheRsaSha256(this.bufferPool, this.random))
             {
                 byte[] sharedKey = new byte[cipherSuite.SharedKeySize()];
                 Assert.IsFalse(cipherSuite.VerifyClientMessageAndGenerateSharedKey(sharedKey, data));
@@ -107,7 +109,7 @@ namespace Hazel.UnitTests.Dtls
         {
             byte[] data;
 
-            using (X25519EcdheRsaSha256 cipherSuite = new X25519EcdheRsaSha256(this.random))
+            using (X25519EcdheRsaSha256 cipherSuite = new X25519EcdheRsaSha256(this.bufferPool, this.random))
             {
                 int expectedSize = cipherSuite.CalculateClientMessageSize();
                 Assert.IsTrue(expectedSize > 0);
@@ -116,7 +118,7 @@ namespace Hazel.UnitTests.Dtls
                 random.GetBytes(data);
             }
 
-            using (X25519EcdheRsaSha256 cipherSuite = new X25519EcdheRsaSha256(this.random))
+            using (X25519EcdheRsaSha256 cipherSuite = new X25519EcdheRsaSha256(this.bufferPool, this.random))
             {
                 byte[] sharedKey = new byte[cipherSuite.SharedKeySize()];
                 Assert.IsFalse(cipherSuite.VerifyClientMessageAndGenerateSharedKey(sharedKey, data));
@@ -128,7 +130,7 @@ namespace Hazel.UnitTests.Dtls
         {
             byte[] data;
 
-            using (X25519EcdheRsaSha256 cipherSuite = new X25519EcdheRsaSha256(this.random))
+            using (X25519EcdheRsaSha256 cipherSuite = new X25519EcdheRsaSha256(this.bufferPool, this.random))
             {
                 int expectedSize = cipherSuite.CalculateClientMessageSize();
                 Assert.IsTrue(expectedSize > 0);
@@ -137,7 +139,7 @@ namespace Hazel.UnitTests.Dtls
                 random.GetBytes(data);
             }
 
-            using (X25519EcdheRsaSha256 cipherSuite = new X25519EcdheRsaSha256(this.random))
+            using (X25519EcdheRsaSha256 cipherSuite = new X25519EcdheRsaSha256(this.bufferPool, this.random))
             {
                 byte[] sharedKey = new byte[cipherSuite.SharedKeySize()];
                 Assert.IsFalse(cipherSuite.VerifyClientMessageAndGenerateSharedKey(sharedKey, data));
@@ -149,7 +151,7 @@ namespace Hazel.UnitTests.Dtls
         {
             byte[] data;
 
-            using (X25519EcdheRsaSha256 cipherSuite = new X25519EcdheRsaSha256(this.random))
+            using (X25519EcdheRsaSha256 cipherSuite = new X25519EcdheRsaSha256(this.bufferPool, this.random))
             {
                 int expectedSize = cipherSuite.CalculateServerMessageSize(this.privateKey);
                 Assert.IsTrue(expectedSize > 0);
@@ -163,7 +165,7 @@ namespace Hazel.UnitTests.Dtls
             random.GetBytes(randomSignature);
             new ByteSpan(randomSignature).CopyTo(new ByteSpan(data, data.Length - randomSignature.Length, randomSignature.Length));
 
-            using (X25519EcdheRsaSha256 cipherSuite = new X25519EcdheRsaSha256(this.random))
+            using (X25519EcdheRsaSha256 cipherSuite = new X25519EcdheRsaSha256(this.bufferPool, this.random))
             {
                 byte[] sharedKey = new byte[cipherSuite.SharedKeySize()];
                 Assert.IsFalse(cipherSuite.VerifyServerMessageAndGenerateSharedKey(sharedKey, data, this.publicKey));
@@ -175,7 +177,7 @@ namespace Hazel.UnitTests.Dtls
         {
             byte[] data;
 
-            using (X25519EcdheRsaSha256 cipherSuite = new X25519EcdheRsaSha256(this.random))
+            using (X25519EcdheRsaSha256 cipherSuite = new X25519EcdheRsaSha256(this.bufferPool, this.random))
             {
                 int expectedSize = cipherSuite.CalculateServerMessageSize(this.privateKey);
                 Assert.IsTrue(expectedSize > 0);
@@ -184,7 +186,7 @@ namespace Hazel.UnitTests.Dtls
                 cipherSuite.EncodeServerKeyExchangeMessage(data, this.privateKey);
             }
 
-            using (X25519EcdheRsaSha256 cipherSuite = new X25519EcdheRsaSha256(this.random))
+            using (X25519EcdheRsaSha256 cipherSuite = new X25519EcdheRsaSha256(this.bufferPool, this.random))
             {
                 byte[] sharedKey = new byte[cipherSuite.SharedKeySize()];
                 Assert.IsTrue(cipherSuite.VerifyServerMessageAndGenerateSharedKey(sharedKey, data, this.publicKey));
@@ -197,7 +199,7 @@ namespace Hazel.UnitTests.Dtls
             byte[] serverSharedSecret;
             byte[] clientSharedSecret;
 
-            using (X25519EcdheRsaSha256 serverCipherSuite = new X25519EcdheRsaSha256(this.random))
+            using (X25519EcdheRsaSha256 serverCipherSuite = new X25519EcdheRsaSha256(this.bufferPool, this.random))
             {
                 int expectedSize = serverCipherSuite.CalculateServerMessageSize(this.privateKey);
                 Assert.IsTrue(expectedSize > 0);
@@ -207,7 +209,7 @@ namespace Hazel.UnitTests.Dtls
 
                 byte[] clientKeyExchange;
 
-                using (X25519EcdheRsaSha256 clientCipherSuite = new X25519EcdheRsaSha256(this.random))
+                using (X25519EcdheRsaSha256 clientCipherSuite = new X25519EcdheRsaSha256(this.bufferPool, this.random))
                 {
                     clientSharedSecret = new byte[clientCipherSuite.SharedKeySize()];
                     Assert.IsTrue(clientCipherSuite.VerifyServerMessageAndGenerateSharedKey(clientSharedSecret, serverKeyExchangeMessage, this.publicKey));

--- a/Hazel/ByteSpan.cs
+++ b/Hazel/ByteSpan.cs
@@ -10,6 +10,16 @@ namespace Hazel
         private readonly byte[] array_;
 
         /// <summary>
+        /// Returns the offset into the underlying array
+        /// </summary>
+        public readonly int Offset;
+
+        /// <summary>
+        /// Returns the length of the current span
+        /// </summary>
+        public readonly int Length;
+
+        /// <summary>
         /// Createa a new span object containing an entire array
         /// </summary>
         public ByteSpan(byte[] array)
@@ -78,16 +88,6 @@ namespace Hazel
         {
             return this.array_;
         }
-
-        /// <summary>
-        /// Returns the offset into the underlying array
-        /// </summary>
-        public int Offset { get; }
-
-        /// <summary>
-        /// Returns the length of the current span
-        /// </summary>
-        public int Length { get; }
 
         /// <summary>
         /// Gets the span element at the specified index

--- a/Hazel/Crypto/SpanCryptoExtensions.cs
+++ b/Hazel/Crypto/SpanCryptoExtensions.cs
@@ -22,15 +22,7 @@ namespace Hazel.Crypto
         /// <param name="random">Entropy source</param>
         public static void FillWithRandom(this ByteSpan span, RandomNumberGenerator random)
         {
-            if (span.Offset == 0 && span.Length == span.GetUnderlyingArray().Length)
-            {
-                random.GetBytes(span.GetUnderlyingArray());
-                return;
-            }
-
-            byte[] temp = new byte[span.Length];
-            random.GetBytes(temp);
-            new ByteSpan(temp).CopyTo(span);
+            random.GetBytes(span.GetUnderlyingArray(), span.Offset, span.Length);
         }
     }
 }

--- a/Hazel/Dtls/IRecordProtection.cs
+++ b/Hazel/Dtls/IRecordProtection.cs
@@ -69,15 +69,15 @@ namespace Hazel.Dtls
     /// </summary>
     public sealed class RecordProtectionFactory
     {
-        public static IRecordProtection Create(CipherSuite cipherSuite, ByteSpan masterSecret, ByteSpan serverRandom, ByteSpan clientRandom)
+        public static IRecordProtection Create(ObjectPool<SmartBuffer> bufferPool, CipherSuite cipherSuite, ByteSpan masterSecret, ByteSpan serverRandom, ByteSpan clientRandom)
         {
             switch (cipherSuite)
             {
-            case CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256:
-                return new Aes128GcmRecordProtection(masterSecret, serverRandom, clientRandom);
+                case CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256:
+                    return new Aes128GcmRecordProtection(bufferPool, masterSecret, serverRandom, clientRandom);
 
-            default:
-                return null;
+                default:
+                    return null;
             }
         }
     }


### PR DESCRIPTION
Biggest thing is trying to reduce how often the [] overload is called. It's called SO MUCH. Also Offset and Size secretly get called ALL THE TIME.

Biggest refactor here though is `AesGcm.MultiplyGF128Elements`. This method can call ByteSpan Get/Set item *~450k times* per packet. Especially with that awful "SecureClear" implementation. I haven't load tested it yet, but this might actually shave milliseconds per packet sent/received.

On the allocations side, it's really just a bunch of temp buffers everywhere. Nothing huge, but maybe like 100 bytes per packet sorta stuff. The biggest one is probably `PrfSha256.ExpandSecret` which gets called fairly often and allocates a bunch of temp buffers. But that's mostly during the handshaking process, so it's probably not a huge deal.

This probably still isn't everything. This is just high targets during profiling and stuff I noticed.

Might need to edit this later, but early benchmarking suggests that this and the reduce-allocs branch improve DTLS RTT by 50%