### PR TITLE
Fix ordering of thread clean-up on dispose to fix tests in newer .net versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest ]
+        os: [ ubuntu-22.04, windows-latest ]
 
     steps:
       - uses: actions/checkout@v2

--- a/Hazel.UnitTests/SocketCapture.cs
+++ b/Hazel.UnitTests/SocketCapture.cs
@@ -144,41 +144,55 @@ namespace Hazel.UnitTests
 
         private void SendToRemoteLoop()
         {
-            while (!this.cancellationToken.IsCancellationRequested)
+            try
             {
-                if (this.SendToRemoteSemaphore != null)
+                while (!this.cancellationToken.IsCancellationRequested)
                 {
-                    if (!this.SendToRemoteSemaphore.WaitOne(100))
+                    if (this.SendToRemoteSemaphore != null)
                     {
-                        continue;
+                        if (!this.SendToRemoteSemaphore.WaitOne(100))
+                        {
+                            continue;
+                        }
+                    }
+
+                    if (this.forRemote.TryTake(out var packet))
+                    {
+                        this.logger.WriteInfo($"Passed 1 packet of {packet.Length} bytes to remote");
+                        this.captureSocket.SendTo(packet.GetUnderlyingArray(), packet.Offset, packet.Length, SocketFlags.None, this.remoteEndPoint);
                     }
                 }
-
-                if (this.forRemote.TryTake(out var packet))
-                {
-                    this.logger.WriteInfo($"Passed 1 packet of {packet.Length} bytes to remote");
-                    this.captureSocket.SendTo(packet.GetUnderlyingArray(), packet.Offset, packet.Length, SocketFlags.None, this.remoteEndPoint);
-                }
+            }
+            catch
+            {
+                //
             }
         }
 
         private void SendToLocalLoop()
         {
-            while (!this.cancellationToken.IsCancellationRequested)
+            try
             {
-                if (this.SendToLocalSemaphore != null)
+                while (!this.cancellationToken.IsCancellationRequested)
                 {
-                    if (!this.SendToLocalSemaphore.WaitOne(100))
+                    if (this.SendToLocalSemaphore != null)
                     {
-                        continue;
+                        if (!this.SendToLocalSemaphore.WaitOne(100))
+                        {
+                            continue;
+                        }
+                    }
+
+                    if (this.forLocal.TryTake(out var packet))
+                    {
+                        this.logger.WriteInfo($"Passed 1 packet of {packet.Length} bytes to local");
+                        this.captureSocket.SendTo(packet.GetUnderlyingArray(), packet.Offset, packet.Length, SocketFlags.None, this.localEndPoint);
                     }
                 }
-
-                if (this.forLocal.TryTake(out var packet))
-                {
-                    this.logger.WriteInfo($"Passed 1 packet of {packet.Length} bytes to local");
-                    this.captureSocket.SendTo(packet.GetUnderlyingArray(), packet.Offset, packet.Length, SocketFlags.None, this.localEndPoint);
-                }
+            }
+            catch
+            {
+                //
             }
         }
 

--- a/Hazel.UnitTests/ThreadLimitedUdpConnectionTests.cs
+++ b/Hazel.UnitTests/ThreadLimitedUdpConnectionTests.cs
@@ -297,6 +297,9 @@ namespace Hazel.UnitTests
 
                         capture.SendToLocalSemaphore.Release(); // Actually let it send.
                         capture.AssertPacketsToLocalCountEquals(0);
+                        
+                        // Allow time to prevent out of order (probably)
+                        Thread.Sleep(100);
                     }
                 }
 

--- a/Hazel/FewerThreads/ThreadLimitedUdpConnectionListener.cs
+++ b/Hazel/FewerThreads/ThreadLimitedUdpConnectionListener.cs
@@ -376,24 +376,19 @@ namespace Hazel.Udp.FewerThreads
 
             // Flush outgoing packets
             this.sendQueue?.CompleteAdding();
+            this.receiveQueue?.CompleteAdding();
 
             if (wasActive)
             {
                 this.sendThread.Join();
+                this.reliablePacketThread.Join();
+                this.receiveThread.Join();
+                this.processThreads.Join();
             }
 
             try { this.socket.Shutdown(SocketShutdown.Both); } catch { }
             try { this.socket.Close(); } catch { }
             try { this.socket.Dispose(); } catch { }
-
-            this.receiveQueue?.CompleteAdding();
-
-            if (wasActive)
-            {
-                this.reliablePacketThread.Join();
-                this.receiveThread.Join();
-                this.processThreads.Join();
-            }
 
             this.receiveQueue?.Dispose();
             this.receiveQueue = null;


### PR DESCRIPTION
When attempting to update a consuming application to a newer version of dotnet (specifically .NET 6), certain Hazel related tests would fail.

Turned out that, on dispose, `ThreadLimitedUdpConnectionListener` would clean up threads out of order, causing the chance of an unhandled socket exception (ie. Shutdown called on the socket before a thread tries to use the socket). It's a mystery why the tests would by-chance work previously all the time and then start to fail consistently post dotnet upgrade.

Likewise, upgrading Hazel to .NET 6 also caused tests to fail. So that was used as a test case for testing the fixes made.