### PR TITLE
Specify ubuntu version to fix CI github action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest ]
+        os: [ ubuntu-22.04, windows-latest ]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
CI ubuntu build would error on step Test with:

`System.IO.FileNotFoundException: Could not find 'mono' host. Make sure that 'mono' is installed on the machine and is available in PATH environment variable.`

Changing to ubuntu-22.04 fixed the issue