### PR TITLE
Fragmentation support

### DIFF
--- a/Hazel/Dtls/DtlsConnectionListener.cs
+++ b/Hazel/Dtls/DtlsConnectionListener.cs
@@ -8,6 +8,7 @@ using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using Hazel.Udp.FewerThreads;
 using Hazel.Crypto;
+using System.Net.Sockets;
 
 namespace Hazel.Dtls
 {
@@ -543,9 +544,6 @@ namespace Hazel.Dtls
                     continue;
                 }
 
-                ByteSpan packet;
-                ByteSpan writer;
-
 #if DEBUG
                 this.Logger.WriteVerbose($"Received handshake {handshake.MessageType} ({peer.NextEpoch.State})");
 #endif
@@ -800,7 +798,7 @@ namespace Hazel.Dtls
             // Current epoch can now handle application data
             peer.CanHandleApplicationData = true;
 
-            base.QueueRawData(buffer, peerAddress);
+            base.QueueRawData(buffer, peerAddress, null);
         }
 
         /// <summary>
@@ -1031,7 +1029,7 @@ namespace Hazel.Dtls
                 ref initialRecord
             );
 
-            base.QueueRawData(initialBuffer, peerAddress);
+            base.QueueRawData(initialBuffer, peerAddress, null);
 
             // Record record payload for verification
             if (recordMessagesForVerifyData)
@@ -1096,7 +1094,7 @@ namespace Hazel.Dtls
                     ref additionalRecord
                 );
 
-                base.QueueRawData(certBuffer, peerAddress);
+                base.QueueRawData(certBuffer, peerAddress, null);
             }
 
             // Describe final record of the flight
@@ -1158,7 +1156,7 @@ namespace Hazel.Dtls
                 ref finalRecord
             );
 
-            base.QueueRawData(finalBuffer, peerAddress);
+            base.QueueRawData(finalBuffer, peerAddress, null);
 
             return true;
         }
@@ -1299,13 +1297,13 @@ namespace Hazel.Dtls
                 ref record
             );
 
-            base.QueueRawData(buffer, peerAddress);
+            base.QueueRawData(buffer, peerAddress, null);
         }
 
         /// <summary>
         /// Handle a requrest to send a datagram to the network
         /// </summary>
-        protected override void QueueRawData(SmartBuffer span, IPEndPoint remoteEndPoint)
+        protected override void QueueRawData(SmartBuffer span, IPEndPoint remoteEndPoint, Action<SocketException> onError)
         {
             if (!this.existingPeers.TryGetValue(remoteEndPoint, out PeerData peer))
             {
@@ -1353,7 +1351,7 @@ namespace Hazel.Dtls
                         ref outgoingRecord
                     );
 
-                    base.QueueRawData(buffer, remoteEndPoint);
+                    base.QueueRawData(buffer, remoteEndPoint, onError);
                 }
 
                 {
@@ -1381,7 +1379,7 @@ namespace Hazel.Dtls
                         ref outgoingRecord
                     );
 
-                    base.QueueRawData(buffer, remoteEndPoint);
+                    base.QueueRawData(buffer, remoteEndPoint, null);
                 }
             }
         }

--- a/Hazel/Dtls/DtlsUnityConnection.cs
+++ b/Hazel/Dtls/DtlsUnityConnection.cs
@@ -352,13 +352,13 @@ namespace Hazel.Dtls
         }
 
         /// <inheritdoc />
-        protected override void WriteBytesToConnection(SmartBuffer bytes, int length)
+        protected override void WriteBytesToConnection(SmartBuffer bytes, int length, Action<System.Net.Sockets.SocketException> onError = null)
         {
             using SmartBuffer wireData = this.WriteBytesToConnectionInternal(bytes, length);
             
             if (wireData.Length > 0)
             {
-                base.WriteBytesToConnection(wireData, wireData.Length);
+                base.WriteBytesToConnection(wireData, wireData.Length, onError);
             }
         }
 

--- a/Hazel/FewerThreads/ThreadLimitedUdpConnectionListener.cs
+++ b/Hazel/FewerThreads/ThreadLimitedUdpConnectionListener.cs
@@ -17,6 +17,7 @@ namespace Hazel.Udp.FewerThreads
         {
             public SmartBuffer Span;
             public IPEndPoint Recipient;
+            public Action<SocketException> OnError;
         }
 
         private struct ReceiveMessageInfo
@@ -258,6 +259,16 @@ namespace Hazel.Udp.FewerThreads
                         break;
                     }
                 }
+                catch (SocketException ex)
+                {
+                    msg.OnError?.Invoke(ex);
+                    if (msg.OnError == null)
+                    {
+                        this.Logger.WriteError("Error in loop while sending: " + ex.Message);
+                    }
+
+                    Thread.Sleep(1);
+                }
                 catch (Exception e)
                 {
                     this.Logger.WriteError("Error in loop while sending: " + e.Message);
@@ -337,15 +348,15 @@ namespace Hazel.Udp.FewerThreads
             connection.HandleReceive(message, bytesReceived);
         }
 
-        internal void SendDataRaw(SmartBuffer response, IPEndPoint remoteEndPoint)
+        internal void SendDataRaw(SmartBuffer response, IPEndPoint remoteEndPoint, Action<SocketException> onError = null)
         {
-            QueueRawData(response, remoteEndPoint);
+            QueueRawData(response, remoteEndPoint, onError);
         }
 
-        protected virtual void QueueRawData(SmartBuffer span, IPEndPoint remoteEndPoint)
+        protected virtual void QueueRawData(SmartBuffer span, IPEndPoint remoteEndPoint, Action<SocketException> onError)
         {
             span.AddUsage();
-            this.sendQueue.TryAdd(new SendMessageInfo() { Span = span, Recipient = remoteEndPoint });
+            this.sendQueue.TryAdd(new SendMessageInfo() { Span = span, Recipient = remoteEndPoint, OnError = onError });
         }
 
         /// <summary>

--- a/Hazel/FewerThreads/ThreadLimitedUdpConnectionListener.cs
+++ b/Hazel/FewerThreads/ThreadLimitedUdpConnectionListener.cs
@@ -32,6 +32,11 @@ namespace Hazel.Udp.FewerThreads
         private Socket socket;
         protected ILogger Logger;
 
+        /// <summary>
+        /// Whether application-level fragmentation and MTU discovery are enabled for connections created by this listener.
+        /// </summary>
+        public bool FragmentationEnabled { get; }
+
         private Thread reliablePacketThread;
         private Thread receiveThread;
         private Thread sendThread;
@@ -106,15 +111,17 @@ namespace Hazel.Udp.FewerThreads
 
         private bool isActive;
 
-        public ThreadLimitedUdpConnectionListener(int numWorkers, IPEndPoint endPoint, ILogger logger, IPMode ipMode = IPMode.IPv4)
+        public ThreadLimitedUdpConnectionListener(int numWorkers, IPEndPoint endPoint, ILogger logger, IPMode ipMode = IPMode.IPv4, bool enableFragmentation = false)
         {
             this.Logger = logger;
             this.EndPoint = endPoint;
             this.IPMode = ipMode;
 
+            this.FragmentationEnabled = enableFragmentation;
+
             this.receiveQueue = new BlockingCollection<ReceiveMessageInfo>(10000);
 
-            this.socket = UdpConnection.CreateSocket(this.IPMode);
+            this.socket = UdpConnection.CreateSocket(this.IPMode, enableFragmentation);
             this.socket.ExclusiveAddressUse = true;
             this.socket.Blocking = false;
 
@@ -316,7 +323,7 @@ namespace Hazel.Udp.FewerThreads
                         }
 
                         aware = false;
-                        connection = new ThreadLimitedUdpServerConnection(this, connectionId, remoteEndPoint, this.IPMode, this.Logger);
+                        connection = new ThreadLimitedUdpServerConnection(this, connectionId, remoteEndPoint, this.IPMode, this.Logger, this.FragmentationEnabled);
                         if (!this.allConnections.TryAdd(connectionId, connection))
                         {
                             throw new HazelException("Failed to add a connection. This should never happen.");

--- a/Hazel/FewerThreads/ThreadLimitedUdpConnectionListener.cs
+++ b/Hazel/FewerThreads/ThreadLimitedUdpConnectionListener.cs
@@ -345,7 +345,10 @@ namespace Hazel.Udp.FewerThreads
                 }
 
                 // Send our hello version back so the client can negotiate too.
-                connection.SendHelloResponse();
+                if (this.FragmentationEnabled)
+                {
+                    connection.SendHelloResponse();
+                }
 
                 // Skip header and hello byte;
                 message.Offset = 4;

--- a/Hazel/FewerThreads/ThreadLimitedUdpConnectionListener.cs
+++ b/Hazel/FewerThreads/ThreadLimitedUdpConnectionListener.cs
@@ -337,6 +337,16 @@ namespace Hazel.Udp.FewerThreads
             // subsequent messages can happen before the NewConnection event sets up OnDataRecieved handlers
             if (!aware)
             {
+                // Negotiate capabilities using the hello version byte.
+                // Layout: [SendOption(1)][ReliableId(2)][HelloVersion(1)]...
+                if (bytesReceived >= 4)
+                {
+                    connection.SetRemoteHelloVersion(message.Buffer[3]);
+                }
+
+                // Send our hello version back so the client can negotiate too.
+                connection.SendHelloResponse();
+
                 // Skip header and hello byte;
                 message.Offset = 4;
                 message.Length = bytesReceived - 4;

--- a/Hazel/FewerThreads/ThreadLimitedUdpServerConnection.cs
+++ b/Hazel/FewerThreads/ThreadLimitedUdpServerConnection.cs
@@ -38,10 +38,11 @@ namespace Hazel.Udp.FewerThreads
 
             State = ConnectionState.Connected;
             this.InitializeKeepAliveTimer();
+            this.StartMtuDiscovery();
         }
 
         /// <inheritdoc />
-        protected override void WriteBytesToConnection(SmartBuffer bytes, int length)
+        protected override void WriteBytesToConnection(SmartBuffer bytes, int length, Action<System.Net.Sockets.SocketException> onError = null)
         {
             if (bytes.Length != length) throw new ArgumentException("I made an assumption here. I hope you see this error.");
 
@@ -49,7 +50,7 @@ namespace Hazel.Udp.FewerThreads
             // but I don't want to have a bunch of client references in the send queue...
             // Does this perhaps mean the encryption is being done in the wrong class?
             this.Statistics.LogPacketSend(length);
-            Listener.SendDataRaw(bytes, EndPoint);
+            Listener.SendDataRaw(bytes, EndPoint, onError);
         }
 
         /// <inheritdoc />

--- a/Hazel/FewerThreads/ThreadLimitedUdpServerConnection.cs
+++ b/Hazel/FewerThreads/ThreadLimitedUdpServerConnection.cs
@@ -28,8 +28,8 @@ namespace Hazel.Udp.FewerThreads
         /// <param name="listener">The listener that created this connection.</param>
         /// <param name="endPoint">The endpoint that we are connected to.</param>
         /// <param name="IPMode">The IPMode we are connected using.</param>
-        internal ThreadLimitedUdpServerConnection(ThreadLimitedUdpConnectionListener listener, ThreadLimitedUdpConnectionListener.ConnectionId connectionId, IPEndPoint endPoint, IPMode IPMode, ILogger logger)
-            : base(logger)
+        internal ThreadLimitedUdpServerConnection(ThreadLimitedUdpConnectionListener listener, ThreadLimitedUdpConnectionListener.ConnectionId connectionId, IPEndPoint endPoint, IPMode IPMode, ILogger logger, bool enableFragmentation)
+            : base(logger, enableFragmentation)
         {
             this.Listener = listener;
             this.ConnectionId = connectionId;

--- a/Hazel/Udp/HazelHelloVersion.cs
+++ b/Hazel/Udp/HazelHelloVersion.cs
@@ -1,0 +1,19 @@
+namespace Hazel.Udp
+{
+    /// <summary>
+    /// Version/capabilities byte carried as the first byte of the UDP Hello payload.
+    /// This byte is not exposed to application-level handshake payload (it is stripped by listeners).
+    /// </summary>
+    public enum HazelHelloVersion : byte
+    {
+        /// <summary>
+        /// Legacy Hazel - no UDP fragmentation/MTU discovery support.
+        /// </summary>
+        Legacy = 0,
+
+        /// <summary>
+        /// Supports UDP fragmentation (UdpSendOption.Fragment) and MTU discovery (UdpSendOption.MtuTest).
+        /// </summary>
+        Fragmentation = 1,
+    }
+}

--- a/Hazel/Udp/SendOptionInternal.cs
+++ b/Hazel/Udp/SendOptionInternal.cs
@@ -35,5 +35,10 @@ namespace Hazel.Udp
         ///     Message that is part of a larger, fragmented message.
         /// </summary>
         Fragment = 11,
+
+        /// <summary>
+        ///     Message that is used to discover MTU.
+        /// </summary>
+        MtuTest = 13,
     }
 }

--- a/Hazel/Udp/UdpClientConnection.cs
+++ b/Hazel/Udp/UdpClientConnection.cs
@@ -72,6 +72,15 @@ namespace Hazel.Udp
             catch { }
         }
 
+        protected override void ApplyDontFragment(bool dontFragment)
+        {
+            try
+            {
+                socket.DontFragment = dontFragment;
+            }
+            catch { }
+        }
+
         /// <inheritdoc />
         protected override void WriteBytesToConnection(SmartBuffer bytes, int length, Action<SocketException> onError = null)
         {

--- a/Hazel/Udp/UdpClientConnection.cs
+++ b/Hazel/Udp/UdpClientConnection.cs
@@ -73,30 +73,44 @@ namespace Hazel.Udp
         }
 
         /// <inheritdoc />
-        protected override void WriteBytesToConnection(SmartBuffer bytes, int length)
+        protected override void WriteBytesToConnection(SmartBuffer bytes, int length, Action<SocketException> onError = null)
         {
 #if DEBUG
             if (TestLagMs > 0)
             {
-                ThreadPool.QueueUserWorkItem(a => { Thread.Sleep(this.TestLagMs); WriteBytesToConnectionReal(bytes, length); });
+                ThreadPool.QueueUserWorkItem(a => { Thread.Sleep(this.TestLagMs); WriteBytesToConnectionReal(bytes, length, onError); });
             }
             else
 #endif
             {
-                WriteBytesToConnectionReal(bytes, length);
+                WriteBytesToConnectionReal(bytes, length, onError);
             }
         }
 
-        private void WriteBytesToConnectionReal(SmartBuffer bytes, int length)
+        private sealed class SendContext
+        {
+            public SmartBuffer Buffer;
+            public Action<SocketException> OnError;
+
+            public SendContext(SmartBuffer buffer, Action<SocketException> onError)
+            {
+                Buffer = buffer;
+                OnError = onError;
+            }
+        }
+
+        private void WriteBytesToConnectionReal(SmartBuffer bytes, int length, Action<SocketException> onError)
         {
 #if DEBUG
             DataSentRaw?.Invoke((byte[])bytes, length);
 #endif
 
+            bool addedUsage = false;
             try
             {
                 this.Statistics.LogPacketSend(length);
                 bytes.AddUsage();
+                addedUsage = true;
                 socket.BeginSendTo(
                     (byte[])bytes,
                     0,
@@ -104,21 +118,43 @@ namespace Hazel.Udp
                     SocketFlags.None,
                     EndPoint,
                     HandleSendTo,
-                    bytes);
+                    new SendContext(bytes, onError));
             }
-            catch (NullReferenceException) { }
+            catch (NullReferenceException)
+            {
+                if (addedUsage)
+                {
+                    bytes.Recycle();
+                }
+            }
             catch (ObjectDisposedException)
             {
                 // Already disposed and disconnected...
+                if (addedUsage)
+                {
+                    bytes.Recycle();
+                }
             }
             catch (SocketException ex)
             {
+                if (addedUsage)
+                {
+                    bytes.Recycle();
+                }
+
+                if (onError != null)
+                {
+                    onError(ex);
+                    return;
+                }
+
                 DisconnectInternal(HazelInternalErrors.SocketExceptionSend, "Could not send data as a SocketException occurred: " + ex.Message);
             }
         }
 
         private void HandleSendTo(IAsyncResult result)
         {
+            var ctx = (SendContext)result.AsyncState;
             try
             {
                 socket.EndSendTo(result);
@@ -130,11 +166,18 @@ namespace Hazel.Udp
             }
             catch (SocketException ex)
             {
-                DisconnectInternal(HazelInternalErrors.SocketExceptionSend, "Could not send data as a SocketException occurred: " + ex.Message);
+                if (ctx.OnError != null)
+                {
+                    ctx.OnError(ex);
+                }
+                else
+                {
+                    DisconnectInternal(HazelInternalErrors.SocketExceptionSend, "Could not send data as a SocketException occurred: " + ex.Message);
+                }
             }
             finally
             {
-                ((SmartBuffer)result.AsyncState).Recycle();
+                ctx.Buffer.Recycle();
             }
         }
 
@@ -195,6 +238,7 @@ namespace Hazel.Udp
             {
                 this.State = ConnectionState.Connected;
                 this.InitializeKeepAliveTimer();
+                this.StartMtuDiscovery();
             });
         }
 

--- a/Hazel/Udp/UdpClientConnection.cs
+++ b/Hazel/Udp/UdpClientConnection.cs
@@ -45,13 +45,13 @@ namespace Hazel.Udp
         ///     Creates a new UdpClientConnection.
         /// </summary>
         /// <param name="remoteEndPoint">A <see cref="NetworkEndPoint"/> to connect to.</param>
-        public UdpClientConnection(ILogger logger, IPEndPoint remoteEndPoint, IPMode ipMode = IPMode.IPv4)
-            : base(logger)
+        public UdpClientConnection(ILogger logger, IPEndPoint remoteEndPoint, IPMode ipMode = IPMode.IPv4, bool enableFragmentation = false)
+            : base(logger, enableFragmentation)
         {
             this.EndPoint = remoteEndPoint;
             this.IPMode = ipMode;
 
-            this.socket = CreateSocket(ipMode);
+            this.socket = CreateSocket(ipMode, enableFragmentation);
 
             reliablePacketTimer = new Timer(ManageReliablePacketsInternal, null, 100, Timeout.Infinite);
             this.InitializeKeepAliveTimer();

--- a/Hazel/Udp/UdpConnection.Fragmented.cs
+++ b/Hazel/Udp/UdpConnection.Fragmented.cs
@@ -1,0 +1,288 @@
+using System;
+using System.Collections.Concurrent;
+using System.Net.Sockets;
+using System.Threading;
+
+namespace Hazel.Udp
+{
+    public partial class UdpConnection
+    {
+        /// <summary>
+        /// Maximum possible UDP header size - 60-byte IP header + 8-byte UDP header.
+        /// </summary>
+        public const ushort MaxUdpHeaderSize = 68;
+
+        /// <summary>
+        /// Popular MTU values used for quick MTU discovery.
+        /// </summary>
+        public static ushort[] PossibleMtu { get; } =
+        {
+            576 - MaxUdpHeaderSize, // RFC 1191
+            1024,
+            1460 - MaxUdpHeaderSize, // Google Cloud
+            1492 - MaxUdpHeaderSize, // RFC 1042
+            1500 - MaxUdpHeaderSize, // RFC 1191
+        };
+
+        private int _mtu = PossibleMtu[0];
+
+        /// <summary>
+        /// MTU of this connection.
+        /// </summary>
+        public int Mtu => ForcedMtu ?? _mtu;
+
+        /// <summary>
+        /// Forced MTU, overrides the discovered MTU.
+        /// </summary>
+        public int? ForcedMtu { get; set; } = null;
+
+        /// <summary>
+        ///     Called when the MTU changes.
+        /// </summary>
+        public event Action MtuChanged;
+
+        private byte _mtuIndex;
+
+        private readonly ConcurrentDictionary<ushort, FragmentedMessage> _fragmentedMessagesReceived = new ConcurrentDictionary<ushort, FragmentedMessage>();
+        private volatile int _lastFragmentedId;
+
+        protected void StartMtuDiscovery()
+        {
+            if (ForcedMtu.HasValue)
+            {
+                return;
+            }
+
+            MtuTest(_mtuIndex);
+        }
+
+        private void MtuTest(byte index)
+        {
+            var mtu = PossibleMtu[index];
+            var failed = false;
+
+            using SmartBuffer buffer = this.bufferPool.GetObject();
+            buffer.Length = mtu;
+            buffer[0] = (byte)UdpSendOption.MtuTest;
+
+            // The MTU test message has an extra 2-byte MTU marker at the end. If it arrives, we can verify it.
+            // Because the underlying socket has DontFragment=true, an oversized packet should fail fast with a SocketException.
+            var id = AttachReliableID(buffer, 1, buffer.Length, () =>
+            {
+                if (failed) return;
+                MtuOk(index);
+            });
+
+            buffer[mtu - 2] = (byte)mtu;
+            buffer[mtu - 1] = (byte)(mtu >> 8);
+
+            WriteBytesToConnection(buffer, buffer.Length, (SocketException _) =>
+            {
+                failed = true;
+                CancelReliableMessageId(id);
+
+                if (index == 0)
+                {
+                    DisconnectInternal(HazelInternalErrors.ConnectionDisconnected, "Connection MTU is lower than the minimum");
+                }
+            });
+        }
+
+        private void MtuOk(byte index)
+        {
+            _mtuIndex = index;
+            _mtu = PossibleMtu[index];
+            MtuChanged?.Invoke();
+
+            if (_mtuIndex < PossibleMtu.Length - 1)
+            {
+                MtuTest((byte)(index + 1));
+            }
+        }
+
+        private void MtuTestMessageReceive(MessageReader message)
+        {
+            message.Position = message.Length - 2;
+            var mtu = message.ReadUInt16();
+
+            if (mtu != message.Length)
+            {
+                return;
+            }
+
+            ProcessReliableReceive(message.Buffer, 1, out _);
+        }
+
+        // UdpSendOption.Fragment + ReliableID (2) + MessageId (2) + FragmentsCount (1) + FragmentId (1)
+        private const byte FragmentHeaderSize = sizeof(byte) + sizeof(ushort) + sizeof(ushort) + sizeof(byte) + sizeof(byte);
+
+        /// <summary>
+        /// Fragments and sends a reliable message.
+        /// </summary>
+        protected void FragmentedSend(byte sendOption, byte[] data, Action ackCallback = null)
+        {
+            var length = data.Length + 1; // +1 for sendOption stored in the first fragment payload
+
+            var id = (ushort)Interlocked.Increment(ref _lastFragmentedId);
+            var fragmentSize = Mtu;
+            var fragmentDataSize = fragmentSize - FragmentHeaderSize;
+
+            if (fragmentDataSize <= 1)
+            {
+                throw new HazelException("MTU is too low to support fragmentation");
+            }
+
+            var fragmentsCount = (int)Math.Ceiling(length / (double)fragmentDataSize);
+            if (fragmentsCount > byte.MaxValue)
+            {
+                throw new HazelException("Too many fragments");
+            }
+
+            var acksReceived = 0;
+
+            for (byte i = 0; i < fragmentsCount; i++)
+            {
+                var dataLength = Math.Min(fragmentDataSize, length - fragmentDataSize * i);
+
+                using SmartBuffer buffer = this.bufferPool.GetObject();
+                buffer.Length = dataLength + FragmentHeaderSize;
+
+                buffer[0] = (byte)UdpSendOption.Fragment;
+
+                AttachReliableID(buffer, 1, buffer.Length, () =>
+                {
+                    if (Interlocked.Increment(ref acksReceived) >= fragmentsCount)
+                    {
+                        ackCallback?.Invoke();
+                    }
+                });
+
+                buffer[3] = (byte)id;
+                buffer[4] = (byte)(id >> 8);
+
+                buffer[5] = (byte)fragmentsCount;
+                buffer[6] = i;
+
+                var includingHeader = i == 0;
+                if (includingHeader)
+                {
+                    buffer[7] = sendOption;
+                }
+
+                Buffer.BlockCopy(
+                    data,
+                    fragmentDataSize * i - (includingHeader ? 0 : 1),
+                    (byte[])buffer,
+                    FragmentHeaderSize + (includingHeader ? 1 : 0),
+                    dataLength - (includingHeader ? 1 : 0));
+
+                WriteBytesToConnection(buffer, buffer.Length);
+
+                // Count user payload bytes only (exclude sendOption stored in the first fragment)
+                Statistics.LogFragmentedSend(dataLength - (includingHeader ? 1 : 0));
+            }
+        }
+
+        protected void FragmentMessageReceive(MessageReader messageReader, int bytesReceived)
+        {
+            var isNew = ProcessReliableReceive(messageReader.Buffer, 1, out _);
+
+            messageReader.Position = 3;
+            var fragmentedMessageId = messageReader.ReadUInt16();
+            var fragmentsCount = messageReader.ReadByte();
+            var fragmentId = messageReader.ReadByte();
+
+            if (fragmentsCount <= 0 || fragmentId >= fragmentsCount)
+            {
+                return;
+            }
+
+            var fragmentPayloadLen = bytesReceived - messageReader.Position;
+            var userBytes = fragmentPayloadLen - (fragmentId == 0 ? 1 : 0);
+            Statistics.LogFragmentedReceive(userBytes, bytesReceived);
+
+            if (!isNew)
+            {
+                return;
+            }
+
+            if (!_fragmentedMessagesReceived.TryGetValue(fragmentedMessageId, out var fragmentedMessage))
+            {
+                lock (_fragmentedMessagesReceived)
+                {
+                    if (!_fragmentedMessagesReceived.TryGetValue(fragmentedMessageId, out fragmentedMessage))
+                    {
+                        if (!_fragmentedMessagesReceived.TryAdd(fragmentedMessageId, fragmentedMessage = new FragmentedMessage(fragmentsCount)))
+                        {
+                            throw new HazelException("Failed to add fragmented message");
+                        }
+                    }
+                }
+            }
+
+            lock (fragmentedMessage)
+            {
+                if (fragmentedMessage.Fragments[fragmentId] != null)
+                {
+                    return;
+                }
+
+                var buffer = new byte[fragmentPayloadLen];
+                Buffer.BlockCopy(messageReader.Buffer, messageReader.Position, buffer, 0, fragmentPayloadLen);
+                fragmentedMessage.AddFragment(fragmentId, buffer);
+
+                if (fragmentedMessage.IsFinished)
+                {
+                    var reconstructed = fragmentedMessage.Reconstruct();
+                    var sendOption = (SendOption)reconstructed.Buffer[0];
+                    InvokeDataReceived(sendOption, reconstructed, 1, fragmentedMessage.Size);
+
+                    _fragmentedMessagesReceived.TryRemove(fragmentedMessageId, out _);
+                }
+            }
+        }
+
+        protected class FragmentedMessage
+        {
+            public int FragmentsCount { get; }
+            public int FragmentsReceived { get; private set; }
+            public int Size { get; private set; }
+            public byte[][] Fragments { get; }
+            public bool IsFinished => FragmentsReceived == FragmentsCount;
+
+            public FragmentedMessage(int fragmentsCount)
+            {
+                FragmentsCount = fragmentsCount;
+                Fragments = new byte[fragmentsCount][];
+            }
+
+            public void AddFragment(byte id, byte[] fragment)
+            {
+                Fragments[id] = fragment;
+                Size += fragment.Length;
+                FragmentsReceived++;
+            }
+
+            public MessageReader Reconstruct()
+            {
+                if (!IsFinished)
+                {
+                    throw new HazelException("Can't reconstruct a FragmentedMessage until all fragments are received");
+                }
+
+                var buffer = MessageReader.GetSized(Size);
+                buffer.Length = Size;
+
+                var offset = 0;
+                for (var i = 0; i < FragmentsCount; i++)
+                {
+                    var data = Fragments[i];
+                    Buffer.BlockCopy(data, 0, buffer.Buffer, offset, data.Length);
+                    offset += data.Length;
+                }
+
+                return buffer;
+            }
+        }
+    }
+}

--- a/Hazel/Udp/UdpConnection.Fragmented.cs
+++ b/Hazel/Udp/UdpConnection.Fragmented.cs
@@ -48,6 +48,11 @@ namespace Hazel.Udp
 
         protected void StartMtuDiscovery()
         {
+            if (!this.FragmentationEnabled)
+            {
+                return;
+            }
+
             if (ForcedMtu.HasValue)
             {
                 return;

--- a/Hazel/Udp/UdpConnection.Fragmented.cs
+++ b/Hazel/Udp/UdpConnection.Fragmented.cs
@@ -48,6 +48,11 @@ namespace Hazel.Udp
 
         protected void StartMtuDiscovery()
         {
+            if (!this.UseMtuDiscovery)
+            {
+                return;
+            }
+
             if (!this.FragmentationEnabled)
             {
                 return;

--- a/Hazel/Udp/UdpConnection.Reliable.cs
+++ b/Hazel/Udp/UdpConnection.Reliable.cs
@@ -211,7 +211,7 @@ namespace Hazel.Udp
         /// <param name="buffer">The buffer to attach to.</param>
         /// <param name="offset">The offset to attach at.</param>
         /// <param name="ackCallback">The callback to make once the packet has been acknowledged.</param>
-        protected void AttachReliableID(SmartBuffer buffer, int offset, int length, Action ackCallback = null)
+        protected ushort AttachReliableID(SmartBuffer buffer, int offset, int length, Action ackCallback = null)
         {
             ushort id = (ushort)Interlocked.Increment(ref lastIDAllocated);
 
@@ -236,6 +236,8 @@ namespace Hazel.Udp
             {
                 throw new Exception("That shouldn't be possible");
             }
+
+            return id;
         }
 
         public static int ClampToInt(float value, int min, int max)
@@ -436,6 +438,18 @@ namespace Hazel.Udp
                 {
                     this._pingMs = this._pingMs * .7f + rt * .3f;
                 }
+            }
+        }
+
+        /// <summary>
+        ///     Removes a reliably-sent packet without treating it as acknowledged.
+        ///     Used when a send fails (e.g. MTU discovery).
+        /// </summary>
+        private void CancelReliableMessageId(ushort id)
+        {
+            if (reliableDataPacketsSent.TryRemove(id, out Packet packet))
+            {
+                packet.Recycle();
             }
         }
 

--- a/Hazel/Udp/UdpConnection.cs
+++ b/Hazel/Udp/UdpConnection.cs
@@ -43,7 +43,9 @@ namespace Hazel.Udp
 
             try
             {
-                socket.DontFragment = false;
+                // We do our own application-level fragmentation. Enabling this helps
+                // us detect MTU issues via SocketException (MessageSize) for MTU discovery.
+                socket.DontFragment = true;
             }
             catch { }
 
@@ -61,7 +63,7 @@ namespace Hazel.Udp
         ///     Writes the given bytes to the connection.
         /// </summary>
         /// <param name="bytes">The bytes to write.</param>
-        protected abstract void WriteBytesToConnection(SmartBuffer bytes, int length);
+        protected abstract void WriteBytesToConnection(SmartBuffer bytes, int length, Action<SocketException> onError = null);
 
         /// <inheritdoc/>
         public override SendErrors Send(MessageWriter msg)
@@ -69,6 +71,20 @@ namespace Hazel.Udp
             if (this._state != ConnectionState.Connected)
             {
                 return SendErrors.Disconnected;
+            }
+
+            // We handle fragmentation at the application layer for reliable packets.
+            // Unreliable packets must always fit within the MTU.
+            if (msg.SendOption != SendOption.Reliable && msg.Length > this.Mtu)
+            {
+                throw new HazelException("Unreliable messages can't be bigger than MTU");
+            }
+
+            if (msg.SendOption == SendOption.Reliable && msg.Length > this.Mtu)
+            {
+                ResetKeepAliveTimer();
+                FragmentedSend((byte)SendOption.Reliable, msg.ToByteArray(false));
+                return SendErrors.None;
             }
 
             using SmartBuffer buffer = this.bufferPool.GetObject();
@@ -115,6 +131,7 @@ namespace Hazel.Udp
                 case (byte)UdpSendOption.Ping:
                 case (byte)SendOption.Reliable:
                 case (byte)UdpSendOption.Hello:
+                case (byte)UdpSendOption.MtuTest:
                     ReliableSend(sendOption, data, ackCallback);
                     break;
                                     
@@ -169,6 +186,16 @@ namespace Hazel.Udp
                     Statistics.LogUnreliableReceive(bytesReceived - 1, bytesReceived);
                     break;
 
+                case (byte)UdpSendOption.MtuTest:
+                    MtuTestMessageReceive(message);
+                    message.Recycle();
+                    break;
+
+                case (byte)UdpSendOption.Fragment:
+                    FragmentMessageReceive(message, bytesReceived);
+                    message.Recycle();
+                    break;
+
                 // Treat everything else as garbage
                 default:
                     message.Recycle();
@@ -198,6 +225,11 @@ namespace Hazel.Udp
         /// <param name="length"></param>
         void UnreliableSend(byte sendOption, byte[] data, int offset, int length)
         {
+            if (length + 1 > this.Mtu)
+            {
+                throw new HazelException("Unreliable messages can't be bigger than MTU");
+            }
+
             using SmartBuffer buffer = this.bufferPool.GetObject();
             buffer.Length = length + 1;
 

--- a/Hazel/Udp/UdpConnection.cs
+++ b/Hazel/Udp/UdpConnection.cs
@@ -56,11 +56,20 @@ namespace Hazel.Udp
                 this.FragmentationSupported &&
                 this.RemoteHelloVersion >= HazelHelloVersion.Fragmentation;
 
+            if (wasEnabled != this.FragmentationEnabled)
+            {
+                this.ApplyDontFragment(this.FragmentationEnabled);
+            }
+
             // Start MTU discovery as soon as fragmentation becomes enabled on a connected socket.
             if (!wasEnabled && this.FragmentationEnabled && this._state == ConnectionState.Connected)
             {
                 this.StartMtuDiscovery();
             }
+        }
+
+        protected virtual void ApplyDontFragment(bool dontFragment)
+        {
         }
 
         internal static Socket CreateSocket(IPMode ipMode, bool enableFragmentation = false)
@@ -79,16 +88,12 @@ namespace Hazel.Udp
                 socket.SetSocketOption(SocketOptionLevel.IPv6, SocketOptionName.IPv6Only, false);
             }
 
-            if (enableFragmentation)
+            try
             {
-                try
-                {
-                    // We do our own application-level fragmentation. Enabling this helps
-                    // us detect MTU issues via SocketException (MessageSize) for MTU discovery.
-                    socket.DontFragment = true;
-                }
-                catch { }
+                // Default to OS fragmentation. We only enable DontFragment after capability negotiation.
+                socket.DontFragment = false;
             }
+            catch { }
 
             try
             {

--- a/Hazel/Udp/UdpConnection.cs
+++ b/Hazel/Udp/UdpConnection.cs
@@ -33,6 +33,8 @@ namespace Hazel.Udp
         public override float AveragePingMs => this._pingMs;
         protected readonly ILogger logger;
 
+        protected virtual bool UseMtuDiscovery => true;
+
 
         public UdpConnection(ILogger logger, bool enableFragmentation = false) : base()
         {

--- a/Hazel/Udp/UdpConnection.cs
+++ b/Hazel/Udp/UdpConnection.cs
@@ -11,21 +11,30 @@ namespace Hazel.Udp
     {
         protected readonly ObjectPool<SmartBuffer> bufferPool;
 
+        /// <summary>
+        /// Whether application-level fragmentation and MTU discovery are enabled for this connection.
+        /// When disabled (default), Hazel will not automatically fragment outgoing reliable packets
+        /// and will not perform MTU discovery.
+        /// </summary>
+        public bool FragmentationEnabled { get; }
+
         public static readonly byte[] EmptyDisconnectBytes = new byte[] { (byte)UdpSendOption.Disconnect };
 
         public override float AveragePingMs => this._pingMs;
         protected readonly ILogger logger;
 
 
-        public UdpConnection(ILogger logger) : base()
+        public UdpConnection(ILogger logger, bool enableFragmentation = false) : base()
         {
             this.bufferPool = new ObjectPool<SmartBuffer>(() => new SmartBuffer(this.bufferPool, 1024));
 
             this.logger = logger;
             this.PacketPool = new ObjectPool<Packet>(() => new Packet(this));
+
+            this.FragmentationEnabled = enableFragmentation;
         }
 
-        internal static Socket CreateSocket(IPMode ipMode)
+        internal static Socket CreateSocket(IPMode ipMode, bool enableFragmentation = false)
         {
             Socket socket;
             if (ipMode == IPMode.IPv4)
@@ -41,13 +50,16 @@ namespace Hazel.Udp
                 socket.SetSocketOption(SocketOptionLevel.IPv6, SocketOptionName.IPv6Only, false);
             }
 
-            try
+            if (enableFragmentation)
             {
-                // We do our own application-level fragmentation. Enabling this helps
-                // us detect MTU issues via SocketException (MessageSize) for MTU discovery.
-                socket.DontFragment = true;
+                try
+                {
+                    // We do our own application-level fragmentation. Enabling this helps
+                    // us detect MTU issues via SocketException (MessageSize) for MTU discovery.
+                    socket.DontFragment = true;
+                }
+                catch { }
             }
-            catch { }
 
             try
             {
@@ -73,14 +85,15 @@ namespace Hazel.Udp
                 return SendErrors.Disconnected;
             }
 
-            // We handle fragmentation at the application layer for reliable packets.
-            // Unreliable packets must always fit within the MTU.
-            if (msg.SendOption != SendOption.Reliable && msg.Length > this.Mtu)
-            {
-                throw new HazelException("Unreliable messages can't be bigger than MTU");
-            }
+            // Optional application-level fragmentation and MTU discovery.
+            // If enabled, we can fragment large reliable messages. For unreliable messages
+            // that exceed the MTU we only log a warning and attempt to send without killing
+            // the connection.
+            var isOversizeUnreliable = this.FragmentationEnabled
+                && msg.SendOption != SendOption.Reliable
+                && msg.Length > this.Mtu;
 
-            if (msg.SendOption == SendOption.Reliable && msg.Length > this.Mtu)
+            if (this.FragmentationEnabled && msg.SendOption == SendOption.Reliable && msg.Length > this.Mtu)
             {
                 ResetKeepAliveTimer();
                 FragmentedSend((byte)SendOption.Reliable, msg.ToByteArray(false));
@@ -103,7 +116,16 @@ namespace Hazel.Udp
                         break;
 
                     default:
-                        WriteBytesToConnection(buffer, msg.Length);
+                        if (isOversizeUnreliable)
+                        {
+                            this.logger?.WriteWarning($"Attempted to send unreliable message of size {msg.Length} which exceeds MTU {this.Mtu}. The packet may be dropped.");
+                            // Provide an error handler so we don't disconnect on MessageSize errors.
+                            WriteBytesToConnection(buffer, msg.Length, _ => { });
+                        }
+                        else
+                        {
+                            WriteBytesToConnection(buffer, msg.Length);
+                        }
                         Statistics.LogUnreliableSend(msg.Length - 1);
                         break;
                 }
@@ -187,13 +209,29 @@ namespace Hazel.Udp
                     break;
 
                 case (byte)UdpSendOption.MtuTest:
-                    MtuTestMessageReceive(message);
-                    message.Recycle();
+                    if (this.FragmentationEnabled)
+                    {
+                        MtuTestMessageReceive(message);
+                        message.Recycle();
+                    }
+                    else
+                    {
+                        message.Recycle();
+                        Statistics.LogUnreliableReceive(bytesReceived - 1, bytesReceived);
+                    }
                     break;
 
                 case (byte)UdpSendOption.Fragment:
-                    FragmentMessageReceive(message, bytesReceived);
-                    message.Recycle();
+                    if (this.FragmentationEnabled)
+                    {
+                        FragmentMessageReceive(message, bytesReceived);
+                        message.Recycle();
+                    }
+                    else
+                    {
+                        message.Recycle();
+                        Statistics.LogUnreliableReceive(bytesReceived - 1, bytesReceived);
+                    }
                     break;
 
                 // Treat everything else as garbage
@@ -225,9 +263,10 @@ namespace Hazel.Udp
         /// <param name="length"></param>
         void UnreliableSend(byte sendOption, byte[] data, int offset, int length)
         {
-            if (length + 1 > this.Mtu)
+            var isOversize = this.FragmentationEnabled && (length + 1 > this.Mtu);
+            if (isOversize)
             {
-                throw new HazelException("Unreliable messages can't be bigger than MTU");
+                this.logger?.WriteWarning($"Attempted to send unreliable message of size {length + 1} which exceeds MTU {this.Mtu}. The packet may be dropped.");
             }
 
             using SmartBuffer buffer = this.bufferPool.GetObject();
@@ -237,7 +276,15 @@ namespace Hazel.Udp
             buffer[0] = sendOption;
             Buffer.BlockCopy(data, offset, (byte[])buffer, buffer.Length - length, length);
 
-            WriteBytesToConnection(buffer, buffer.Length);
+            if (isOversize)
+            {
+                // Provide an error handler so we don't disconnect on MessageSize errors.
+                WriteBytesToConnection(buffer, buffer.Length, _ => { });
+            }
+            else
+            {
+                WriteBytesToConnection(buffer, buffer.Length);
+            }
             Statistics.LogUnreliableSend(length);
         }
 

--- a/Hazel/Udp/UdpConnection.cs
+++ b/Hazel/Udp/UdpConnection.cs
@@ -12,11 +12,21 @@ namespace Hazel.Udp
         protected readonly ObjectPool<SmartBuffer> bufferPool;
 
         /// <summary>
-        /// Whether application-level fragmentation and MTU discovery are enabled for this connection.
-        /// When disabled (default), Hazel will not automatically fragment outgoing reliable packets
-        /// and will not perform MTU discovery.
+        /// Whether this endpoint supports application-level fragmentation and MTU discovery.
+        /// This is a local capability flag.
         /// </summary>
-        public bool FragmentationEnabled { get; }
+        public bool FragmentationSupported { get; }
+
+        /// <summary>
+        /// Whether application-level fragmentation and MTU discovery are enabled for this connection.
+        /// This is the negotiated result and is only true when both endpoints support it.
+        /// </summary>
+        public bool FragmentationEnabled { get; private set; }
+
+        /// <summary>
+        /// The remote endpoint's hello version byte (capabilities) as observed from its hello.
+        /// </summary>
+        public HazelHelloVersion RemoteHelloVersion { get; private set; } = HazelHelloVersion.Legacy;
 
         public static readonly byte[] EmptyDisconnectBytes = new byte[] { (byte)UdpSendOption.Disconnect };
 
@@ -31,7 +41,26 @@ namespace Hazel.Udp
             this.logger = logger;
             this.PacketPool = new ObjectPool<Packet>(() => new Packet(this));
 
-            this.FragmentationEnabled = enableFragmentation;
+            this.FragmentationSupported = enableFragmentation;
+
+            // Negotiated later (via hello version exchange). Default to legacy behaviour.
+            this.FragmentationEnabled = false;
+        }
+
+        internal void SetRemoteHelloVersion(byte ver)
+        {
+            RemoteHelloVersion = (HazelHelloVersion)ver;
+
+            var wasEnabled = this.FragmentationEnabled;
+            this.FragmentationEnabled =
+                this.FragmentationSupported &&
+                this.RemoteHelloVersion >= HazelHelloVersion.Fragmentation;
+
+            // Start MTU discovery as soon as fragmentation becomes enabled on a connected socket.
+            if (!wasEnabled && this.FragmentationEnabled && this._state == ConnectionState.Connected)
+            {
+                this.StartMtuDiscovery();
+            }
         }
 
         internal static Socket CreateSocket(IPMode ipMode, bool enableFragmentation = false)
@@ -191,6 +220,12 @@ namespace Hazel.Udp
                     message.Recycle();
                     break;
                 case (byte)UdpSendOption.Hello:
+                    // Hello carries the remote capability byte as the first byte of its payload.
+                    // Layout: [SendOption(1)][ReliableId(2)][HelloVersion(1)]...
+                    if (bytesReceived >= 4)
+                    {
+                        this.SetRemoteHelloVersion(message.Buffer[3]);
+                    }
                     ProcessReliableReceive(message.Buffer, 1, out id);
                     Statistics.LogHelloReceive(bytesReceived);
                     message.Recycle();
@@ -209,7 +244,9 @@ namespace Hazel.Udp
                     break;
 
                 case (byte)UdpSendOption.MtuTest:
-                    if (this.FragmentationEnabled)
+                    // We can safely process MTU test messages as long as we support the feature locally.
+                    // (The negotiated flag only gates what we send.)
+                    if (this.FragmentationSupported)
                     {
                         MtuTestMessageReceive(message);
                         message.Recycle();
@@ -222,7 +259,9 @@ namespace Hazel.Udp
                     break;
 
                 case (byte)UdpSendOption.Fragment:
-                    if (this.FragmentationEnabled)
+                    // We can safely process fragments as long as we support the feature locally.
+                    // (The negotiated flag only gates what we send.)
+                    if (this.FragmentationSupported)
                     {
                         FragmentMessageReceive(message, bytesReceived);
                         message.Recycle();
@@ -321,7 +360,22 @@ namespace Hazel.Udp
                 Buffer.BlockCopy(bytes, 0, actualBytes, 1, bytes.Length);
             }
 
+            // Write our hello version/capability byte.
+            actualBytes[0] = this.FragmentationSupported
+                ? (byte)HazelHelloVersion.Fragmentation
+                : (byte)HazelHelloVersion.Legacy;
+
             HandleSend(actualBytes, (byte)UdpSendOption.Hello, acknowledgeCallback);
+        }
+
+        /// <summary>
+        /// Sends a hello response containing only this endpoint's hello version byte.
+        /// This is used for capability negotiation so that the client can learn the server's capability.
+        /// </summary>
+        internal void SendHelloResponse()
+        {
+            // Empty payload (only the version byte is sent).
+            SendHello(null, null);
         }
                 
         /// <inheritdoc/>

--- a/Hazel/Udp/UdpConnectionListener.cs
+++ b/Hazel/Udp/UdpConnectionListener.cs
@@ -229,6 +229,16 @@ namespace Hazel.Udp
             // subsequent messages can happen before the NewConnection event sets up OnDataRecieved handlers
             if (!aware)
             {
+                // Negotiate capabilities using the hello version byte.
+                // Layout: [SendOption(1)][ReliableId(2)][HelloVersion(1)]...
+                if (bytesReceived >= 4)
+                {
+                    connection.SetRemoteHelloVersion(message.Buffer[3]);
+                }
+
+                // Send our hello version back so the client can negotiate too.
+                connection.SendHelloResponse();
+
                 // Skip header and hello byte;
                 message.Offset = 4;
                 message.Length = bytesReceived - 4;

--- a/Hazel/Udp/UdpConnectionListener.cs
+++ b/Hazel/Udp/UdpConnectionListener.cs
@@ -237,7 +237,10 @@ namespace Hazel.Udp
                 }
 
                 // Send our hello version back so the client can negotiate too.
-                connection.SendHelloResponse();
+                if (this.FragmentationEnabled)
+                {
+                    connection.SendHelloResponse();
+                }
 
                 // Skip header and hello byte;
                 message.Offset = 4;

--- a/Hazel/Udp/UdpConnectionListener.cs
+++ b/Hazel/Udp/UdpConnectionListener.cs
@@ -243,7 +243,7 @@ namespace Hazel.Udp
         /// </summary>
         /// <param name="bytes">The bytes to send.</param>
         /// <param name="endPoint">The endpoint to send to.</param>
-        internal void SendData(SmartBuffer bytes, int length, EndPoint endPoint)
+        internal void SendData(SmartBuffer bytes, int length, EndPoint endPoint, Action<SocketException> onError = null)
         {
             if (length > bytes.Length)
             {
@@ -260,9 +260,11 @@ namespace Hazel.Udp
             }
 #endif
 
+            bool addedUsage = false;
             try
             {
                 bytes.AddUsage();
+                addedUsage = true;
                 socket.BeginSendTo(
                     (byte[])bytes,
                     0,
@@ -270,31 +272,64 @@ namespace Hazel.Udp
                     SocketFlags.None,
                     endPoint,
                     SendCallback,
-                    bytes);
+                    new SendContext(bytes, onError));
 
                 this.Statistics.AddBytesSent(length);
             }
             catch (SocketException e)
             {
-                this.Logger?.WriteError("Could not send data as a SocketException occurred: " + e);
+                if (addedUsage)
+                {
+                    bytes.Recycle();
+                }
+
+                if (onError != null)
+                {
+                    onError(e);
+                }
+                else
+                {
+                    this.Logger?.WriteError("Could not send data as a SocketException occurred: " + e);
+                }
             }
             catch (ObjectDisposedException)
             {
                 //Keep alive timer probably ran, ignore
+                if (addedUsage)
+                {
+                    bytes.Recycle();
+                }
                 return;
+            }
+        }
+
+        private sealed class SendContext
+        {
+            public SmartBuffer Buffer;
+            public Action<SocketException> OnError;
+
+            public SendContext(SmartBuffer buffer, Action<SocketException> onError)
+            {
+                Buffer = buffer;
+                OnError = onError;
             }
         }
 
         private void SendCallback(IAsyncResult result)
         {
+            var ctx = (SendContext)result.AsyncState;
             try
             {
                 socket.EndSendTo(result);
             }
+            catch (SocketException ex)
+            {
+                ctx.OnError?.Invoke(ex);
+            }
             catch { }
             finally
             {
-                ((SmartBuffer)result.AsyncState).Recycle();
+                ctx.Buffer.Recycle();
             }
         }
 

--- a/Hazel/Udp/UdpConnectionListener.cs
+++ b/Hazel/Udp/UdpConnectionListener.cs
@@ -20,6 +20,11 @@ namespace Hazel.Udp
         private ILogger Logger;
         private Timer reliablePacketTimer;
 
+        /// <summary>
+        /// Whether application-level fragmentation and MTU discovery are enabled for connections created by this listener.
+        /// </summary>
+        public bool FragmentationEnabled { get; }
+
         private ConcurrentDictionary<EndPoint, UdpServerConnection> allConnections = new ConcurrentDictionary<EndPoint, UdpServerConnection>();
 
         public override double AveragePing => this.allConnections.Values.Sum(c => c.AveragePingMs) / this.allConnections.Count;
@@ -31,13 +36,15 @@ namespace Hazel.Udp
         ///     Creates a new UdpConnectionListener for the given <see cref="IPAddress"/>, port and <see cref="IPMode"/>.
         /// </summary>
         /// <param name="endPoint">The endpoint to listen on.</param>
-        public UdpConnectionListener(IPEndPoint endPoint, IPMode ipMode = IPMode.IPv4, ILogger logger = null)
+        public UdpConnectionListener(IPEndPoint endPoint, IPMode ipMode = IPMode.IPv4, ILogger logger = null, bool enableFragmentation = false)
         {
             this.Logger = logger;
             this.EndPoint = endPoint;
             this.IPMode = ipMode;
 
-            this.socket = UdpConnection.CreateSocket(this.IPMode);
+            this.FragmentationEnabled = enableFragmentation;
+
+            this.socket = UdpConnection.CreateSocket(this.IPMode, enableFragmentation);
             
             socket.ReceiveBufferSize = SendReceiveBufferSize;
             socket.SendBufferSize = SendReceiveBufferSize;
@@ -208,7 +215,7 @@ namespace Hazel.Udp
                         }
 
                         aware = false;
-                        connection = new UdpServerConnection(this, (IPEndPoint)remoteEndPoint, this.IPMode, this.Logger);
+                        connection = new UdpServerConnection(this, (IPEndPoint)remoteEndPoint, this.IPMode, this.Logger, this.FragmentationEnabled);
                         if (!this.allConnections.TryAdd(remoteEndPoint, connection))
                         {
                             throw new HazelException("Failed to add a connection. This should never happen.");

--- a/Hazel/Udp/UdpServerConnection.cs
+++ b/Hazel/Udp/UdpServerConnection.cs
@@ -33,8 +33,9 @@ namespace Hazel.Udp
 
             State = ConnectionState.Connected;
             this.InitializeKeepAliveTimer();
-            this.StartMtuDiscovery();
         }
+
+        protected override bool UseMtuDiscovery => false;
 
         /// <inheritdoc />
         protected override void WriteBytesToConnection(SmartBuffer bytes, int length, Action<System.Net.Sockets.SocketException> onError = null)

--- a/Hazel/Udp/UdpServerConnection.cs
+++ b/Hazel/Udp/UdpServerConnection.cs
@@ -24,8 +24,8 @@ namespace Hazel.Udp
         /// <param name="listener">The listener that created this connection.</param>
         /// <param name="endPoint">The endpoint that we are connected to.</param>
         /// <param name="IPMode">The IPMode we are connected using.</param>
-        internal UdpServerConnection(UdpConnectionListener listener, IPEndPoint endPoint, IPMode IPMode, ILogger logger)
-            : base(logger)
+        internal UdpServerConnection(UdpConnectionListener listener, IPEndPoint endPoint, IPMode IPMode, ILogger logger, bool enableFragmentation)
+            : base(logger, enableFragmentation)
         {
             this.Listener = listener;
             this.EndPoint = endPoint;

--- a/Hazel/Udp/UdpServerConnection.cs
+++ b/Hazel/Udp/UdpServerConnection.cs
@@ -33,13 +33,14 @@ namespace Hazel.Udp
 
             State = ConnectionState.Connected;
             this.InitializeKeepAliveTimer();
+            this.StartMtuDiscovery();
         }
 
         /// <inheritdoc />
-        protected override void WriteBytesToConnection(SmartBuffer bytes, int length)
+        protected override void WriteBytesToConnection(SmartBuffer bytes, int length, Action<System.Net.Sockets.SocketException> onError = null)
         {
             this.Statistics.LogPacketSend(length);
-            Listener.SendData(bytes, length, EndPoint);
+            Listener.SendData(bytes, length, EndPoint, onError);
         }
 
         /// <inheritdoc />

--- a/Hazel/Udp/UnityUdpClientConnection.cs
+++ b/Hazel/Udp/UnityUdpClientConnection.cs
@@ -26,13 +26,13 @@ namespace Hazel.Udp
 
         private Socket socket;
 
-        public UnityUdpClientConnection(ILogger logger, IPEndPoint remoteEndPoint, IPMode ipMode = IPMode.IPv4)
-            : base(logger)
+        public UnityUdpClientConnection(ILogger logger, IPEndPoint remoteEndPoint, IPMode ipMode = IPMode.IPv4, bool enableFragmentation = false)
+            : base(logger, enableFragmentation)
         {
             this.EndPoint = remoteEndPoint;
             this.IPMode = ipMode;
 
-            this.socket = CreateSocket(ipMode);
+            this.socket = CreateSocket(ipMode, enableFragmentation);
             this.socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ExclusiveAddressUse, true);
         }
         

--- a/Hazel/Udp/UnityUdpClientConnection.cs
+++ b/Hazel/Udp/UnityUdpClientConnection.cs
@@ -62,6 +62,15 @@ namespace Hazel.Udp
             }
         }
 
+        protected override void ApplyDontFragment(bool dontFragment)
+        {
+            try
+            {
+                socket.DontFragment = dontFragment;
+            }
+            catch { }
+        }
+
         protected virtual void RestartConnection()
         {
         }

--- a/Hazel/Udp/UnityUdpClientConnection.cs
+++ b/Hazel/Udp/UnityUdpClientConnection.cs
@@ -71,25 +71,39 @@ namespace Hazel.Udp
         }
 
         /// <inheritdoc />
-        protected override void WriteBytesToConnection(SmartBuffer bytes, int length)
+        protected override void WriteBytesToConnection(SmartBuffer bytes, int length, Action<SocketException> onError = null)
         {
 #if DEBUG
             if (TestLagMs > 0)
             {
-                ThreadPool.QueueUserWorkItem(a => { Thread.Sleep(this.TestLagMs); WriteBytesToConnectionReal(bytes, length); });
+                ThreadPool.QueueUserWorkItem(a => { Thread.Sleep(this.TestLagMs); WriteBytesToConnectionReal(bytes, length, onError); });
             }
             else
 #endif
             {
-                WriteBytesToConnectionReal(bytes, length);
+                WriteBytesToConnectionReal(bytes, length, onError);
             }
         }
 
-        private void WriteBytesToConnectionReal(SmartBuffer bytes, int length)
+        private sealed class SendContext
         {
+            public SmartBuffer Buffer;
+            public Action<SocketException> OnError;
+
+            public SendContext(SmartBuffer buffer, Action<SocketException> onError)
+            {
+                Buffer = buffer;
+                OnError = onError;
+            }
+        }
+
+        private void WriteBytesToConnectionReal(SmartBuffer bytes, int length, Action<SocketException> onError)
+        {
+            bool addedUsage = false;
             try
             {
                 bytes.AddUsage();
+                addedUsage = true;
                 this.Statistics.LogPacketSend(length);
                 socket.BeginSendTo(
                     (byte[])bytes,
@@ -98,20 +112,27 @@ namespace Hazel.Udp
                     SocketFlags.None,
                     EndPoint,
                     HandleSendTo,
-                    bytes);
+                    new SendContext(bytes, onError));
             }
             catch (NullReferenceException)
             {
-                bytes.Recycle();
+                if (addedUsage) bytes.Recycle();
             }
             catch (ObjectDisposedException)
             {
                 // Already disposed and disconnected...
-                bytes.Recycle();
+                if (addedUsage) bytes.Recycle();
             }
             catch (SocketException ex)
             {
-                bytes.Recycle();
+                if (addedUsage) bytes.Recycle();
+
+                if (onError != null)
+                {
+                    onError(ex);
+                    return;
+                }
+
                 DisconnectInternal(HazelInternalErrors.SocketExceptionSend, "Could not send data as a SocketException occurred: " + ex.Message);
             }
         }
@@ -149,6 +170,7 @@ namespace Hazel.Udp
 
         private void HandleSendTo(IAsyncResult result)
         {
+            var ctx = (SendContext)result.AsyncState;
             try
             {
                 socket.EndSendTo(result);
@@ -160,11 +182,18 @@ namespace Hazel.Udp
             }
             catch (SocketException ex)
             {
-                DisconnectInternal(HazelInternalErrors.SocketExceptionSend, "Could not send data as a SocketException occurred: " + ex.Message);
+                if (ctx.OnError != null)
+                {
+                    ctx.OnError(ex);
+                }
+                else
+                {
+                    DisconnectInternal(HazelInternalErrors.SocketExceptionSend, "Could not send data as a SocketException occurred: " + ex.Message);
+                }
             }
             finally
             {
-                ((SmartBuffer)result.AsyncState).Recycle();
+                ctx.Buffer.Recycle();
             }
         }
 
@@ -224,6 +253,7 @@ namespace Hazel.Udp
             {
                 this.InitializeKeepAliveTimer();
                 this.State = ConnectionState.Connected;
+                this.StartMtuDiscovery();
             });
         }
 


### PR DESCRIPTION
My personal implementation of the fragmentation packets support from #36 
It uses the magic version flag defined in Hello packet to check whether client has fragmentation enabled. And server will send back a hello packet to tell client whether fragmentation is enabled server side. In this way we can toggle fragmentation features automatically while keeping support for older versions.
Server and client can choose whether to enable the fragmentation feature. Fragmentation will only work on reliable packets.