### PR TITLE
Fix ReadPackedUInt32 unbounded varint decode (max 5 bytes)

### DIFF
--- a/Hazel.UnitTests/MessageReaderTests.cs
+++ b/Hazel.UnitTests/MessageReaderTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -1121,6 +1121,70 @@ namespace Hazel.UnitTests
             {
                 outer.ReadMessage();
                 Assert.Fail("ReadMessage is expected to throw");
+            }
+            catch (InvalidDataException) { }
+        }
+
+        [TestMethod]
+        public void ReadPackedUInt32AcceptsMaxValue()
+        {
+            var msg = new MessageWriter(32);
+            msg.StartMessage(0);
+            msg.WritePacked(uint.MaxValue);
+            msg.WritePacked(0u);
+            msg.EndMessage();
+
+            // uint.MaxValue encodes to exactly 5 packed bytes.
+            Assert.AreEqual(3 + 5 + 1, msg.Position);
+
+            MessageReader reader = MessageReader.Get(msg.Buffer, 0);
+            Assert.AreEqual(uint.MaxValue, reader.ReadPackedUInt32());
+            Assert.AreEqual(0u, reader.ReadPackedUInt32());
+        }
+
+        [TestMethod]
+        public void ReadPackedUInt32RejectsOverlongEncoding()
+        {
+            // 6-byte varint: five continuation bytes then a terminator.
+            // A uint only needs 5 bytes max; the 6th is rejected via shift >= 35.
+            byte[] overlong = new byte[] { 0x80, 0x80, 0x80, 0x80, 0x80, 0x00 };
+            MessageReader reader = MessageReader.Get(overlong);
+
+            try
+            {
+                reader.ReadPackedUInt32();
+                Assert.Fail("ReadPackedUInt32 is expected to throw for overlong encodings");
+            }
+            catch (InvalidDataException) { }
+        }
+
+        [TestMethod]
+        public void ReadPackedUInt32RejectsFiveContinuationBytes()
+        {
+            // Fifth byte still has the continuation bit set: more than 5 bytes required.
+            byte[] overlong = new byte[] { 0x80, 0x80, 0x80, 0x80, 0x80 };
+            MessageReader reader = MessageReader.Get(overlong);
+
+            try
+            {
+                reader.ReadPackedUInt32();
+                Assert.Fail("ReadPackedUInt32 is expected to throw for encodings longer than 5 bytes");
+            }
+            catch (InvalidDataException) { }
+        }
+
+        [TestMethod]
+        public void ReadPackedUInt32RejectsOutOfRangeFifthByte()
+        {
+            // First four bytes contribute 28 bits of ones; fifth data nibble must be <= 0x0F.
+            // 0x10 would decode past UInt32.MaxValue if accepted.
+            byte[] tooLarge = new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0x10 };
+            MessageReader reader = MessageReader.Get(tooLarge);
+
+            try
+            {
+                reader.ReadPackedUInt32();
+                Assert.Fail("ReadPackedUInt32 is expected to throw when the 5th byte exceeds UInt32 range");
             }
             catch (InvalidDataException) { }
         }

--- a/Hazel/MessageReader.cs
+++ b/Hazel/MessageReader.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -433,30 +433,46 @@ namespace Hazel
         ///
         public uint ReadPackedUInt32()
         {
-            bool readMore = true;
-            int shift = 0;
             uint output = 0;
 
-            while (readMore)
+            for (int index = 0; index < 5; index++)
             {
-                if (this.BytesRemaining < 1) throw new InvalidDataException($"Read length is longer than message length.");
-
-                byte b = this.ReadByte();
-                if (b >= 0x80)
+                if (this.BytesRemaining < 1)
                 {
-                    readMore = true;
-                    b ^= 0x80;
-                }
-                else
-                {
-                    readMore = false;
+                    throw new InvalidDataException(
+                        "Unexpected end of message while reading packed UInt32.");
                 }
 
-                output |= (uint)(b << shift);
-                shift += 7;
+                byte current = this.ReadByte();
+                uint value = (uint)(current & 0x7F);
+
+                if (index == 4)
+                {
+                    // Fifth byte must not request another continuation byte.
+                    if ((current & 0x80) != 0)
+                    {
+                        throw new InvalidDataException(
+                            "Packed UInt32 exceeds maximum of 5 bytes.");
+                    }
+
+                    // Fifth byte may only use the low 4 data bits.
+                    if (value > 0x0F)
+                    {
+                        throw new InvalidDataException(
+                            "Packed UInt32 exceeds UInt32 range.");
+                    }
+                }
+
+                output |= value << (index * 7);
+
+                if ((current & 0x80) == 0)
+                {
+                    return output;
+                }
             }
 
-            return output;
+            throw new InvalidDataException(
+                "Packed UInt32 exceeds maximum of 5 bytes.");
         }
         #endregion
 


### PR DESCRIPTION
`ReadPackedUInt32` looped while the high bit was set with no byte/shift cap. Although `BytesRemaining` bounds runtime, encodings longer than 5 bytes are invalid for `uint` and can wrap under C# shift masking (`shift >= 32`), producing unexpected "valid" values for upper layers.

- Rewrite `MessageReader.ReadPackedUInt32` with a hard 5-byte loop.
- Reject a continuation bit on the 5th byte.
- Reject 5th-byte payload bits above `0x0F` so decoded values stay in `UInt32` range.
- Add unit tests for max value, overlong encodings, and out-of-range fifth bytes.