### PR TITLE
Fix DTLS half-open peer exhaustion and ClientHello RSA signing DoS

### DIFF
--- a/Hazel.UnitTests/UdpReliabilityTests.cs
+++ b/Hazel.UnitTests/UdpReliabilityTests.cs
@@ -106,6 +106,71 @@ namespace Hazel.UnitTests
             Assert.AreEqual(1, (recentPackets >> 1) & 1);
         }
 
+        [TestMethod]
+        public void TestReliableReceiveAcceptsMaximumGap()
+        {
+            List<MessageReader> messagesReceived = new List<MessageReader>();
+            UdpConnectionTestHarness dut = new UdpConnectionTestHarness();
+            dut.Connect();
+            dut.DataReceived += evt => messagesReceived.Add(evt.Message);
+
+            MessageWriter data = MessageWriter.Get(SendOption.Reliable);
+            SetReliableId(data, 256);
+            dut.Test_Receive(data);
+
+            Assert.AreEqual(ConnectionState.Connected, dut.State);
+            Assert.AreEqual(256, dut.ReliableReceiveLast);
+            Assert.AreEqual(1, messagesReceived.Count);
+            Assert.AreEqual(1, dut.BytesSent.Count);
+        }
+
+        [TestMethod]
+        public void TestReliableReceiveDisconnectsWhenGapExceedsLimit()
+        {
+            List<MessageReader> messagesReceived = new List<MessageReader>();
+            HazelInternalErrors? disconnectError = null;
+            UdpConnectionTestHarness dut = new UdpConnectionTestHarness();
+            dut.Connect();
+            dut.DataReceived += evt => messagesReceived.Add(evt.Message);
+            dut.OnInternalDisconnect = error =>
+            {
+                disconnectError = error;
+                return null;
+            };
+
+            MessageWriter data = MessageWriter.Get(SendOption.Reliable);
+            SetReliableId(data, 257);
+            dut.Test_Receive(data);
+
+            Assert.AreEqual(ConnectionState.NotConnected, dut.State);
+            Assert.AreEqual(HazelInternalErrors.ReliablePacketTooFarAhead, disconnectError);
+            Assert.AreEqual(ushort.MaxValue, dut.ReliableReceiveLast);
+            Assert.AreEqual(0, messagesReceived.Count);
+            Assert.AreEqual(0, dut.BytesSent.Count);
+        }
+
+        [TestMethod]
+        public void TestReliableReceiveDisconnectsWhenMissingSetLimitExceeded()
+        {
+            List<MessageReader> messagesReceived = new List<MessageReader>();
+            UdpConnectionTestHarness dut = new UdpConnectionTestHarness();
+            dut.Connect();
+            dut.DataReceived += evt => messagesReceived.Add(evt.Message);
+
+            MessageWriter data = MessageWriter.Get(SendOption.Reliable);
+            SetReliableId(data, 128);
+            dut.Test_Receive(data);
+            SetReliableId(data, 257);
+            dut.Test_Receive(data);
+            SetReliableId(data, 259);
+            dut.Test_Receive(data);
+
+            Assert.AreEqual(ConnectionState.NotConnected, dut.State);
+            Assert.AreEqual(257, dut.ReliableReceiveLast);
+            Assert.AreEqual(2, messagesReceived.Count);
+            Assert.AreEqual(2, dut.BytesSent.Count);
+        }
+
         private static void SetReliableId(MessageWriter data, int i)
         {
             ushort id = (ushort)i;

--- a/Hazel/NetworkConnection.cs
+++ b/Hazel/NetworkConnection.cs
@@ -15,7 +15,8 @@ namespace Hazel
         PingsWithoutResponse,
         ReliablePacketWithoutResponse,
         ConnectionDisconnected,
-        DtlsNegotiationFailed
+        DtlsNegotiationFailed,
+        ReliablePacketTooFarAhead
     }
 
     /// <summary>

--- a/Hazel/Udp/UdpConnection.Reliable.cs
+++ b/Hazel/Udp/UdpConnection.Reliable.cs
@@ -11,6 +11,8 @@ namespace Hazel.Udp
         private const int MinResendDelayMs = 50;
         private const int MaxInitialResendDelayMs = 300;
         private const int MaxAdditionalResendDelayMs = 1000;
+        private const int MaxReliableReceiveGap = 256;
+        private const int MaxMissingReliablePackets = 256;
 
         public readonly ObjectPool<Packet> PacketPool;
 
@@ -327,7 +329,10 @@ namespace Hazel.Udp
              */
 
             bool result = true;
-            
+            bool receiveGapTooLarge = false;
+            int missingCount = 0;
+            int currentMissingCount = 0;
+
             lock (reliableDataPacketsMissing)
             {
                 //Calculate overwritePointer
@@ -343,25 +348,40 @@ namespace Hazel.Udp
                 //If it's new or we've not received anything yet
                 if (isNew)
                 {
-                    // Mark items between the most recent receive and the id received as missing
-                    if (id > reliableReceiveLast)
+                    missingCount = (ushort)(id - reliableReceiveLast) - 1;
+                    currentMissingCount = reliableDataPacketsMissing.Count;
+
+                    if (missingCount > MaxReliableReceiveGap)
                     {
-                        for (ushort i = (ushort)(reliableReceiveLast + 1); i < id; i++)
-                        {
-                            reliableDataPacketsMissing.Add(i);
-                        }
+                        receiveGapTooLarge = true;
                     }
                     else
                     {
-                        int cnt = (ushort.MaxValue - reliableReceiveLast) + id;
-                        for (ushort i = 1; i <= cnt; ++i)
+                        int newMissingCount = 0;
+                        for (int i = 1; i <= missingCount; ++i)
                         {
-                            reliableDataPacketsMissing.Add((ushort)(i + reliableReceiveLast));
+                            if (!reliableDataPacketsMissing.Contains((ushort)(reliableReceiveLast + i)))
+                            {
+                                ++newMissingCount;
+                            }
+                        }
+
+                        if (currentMissingCount + newMissingCount > MaxMissingReliablePackets)
+                        {
+                            receiveGapTooLarge = true;
+                        }
+                        else
+                        {
+                            // Mark items between the most recent receive and the id received as missing.
+                            for (int i = 1; i <= missingCount; ++i)
+                            {
+                                reliableDataPacketsMissing.Add((ushort)(reliableReceiveLast + i));
+                            }
+
+                            //Update the most recently received
+                            reliableReceiveLast = id;
                         }
                     }
-
-                    //Update the most recently received
-                    reliableReceiveLast = id;
                 }
                 
                 //Else it could be a missing packet
@@ -373,6 +393,14 @@ namespace Hazel.Udp
                         result = false;
                     }
                 }
+            }
+
+            if (receiveGapTooLarge)
+            {
+                DisconnectInternal(
+                    HazelInternalErrors.ReliablePacketTooFarAhead,
+                    $"Reliable packet {id} skipped {missingCount} packets with {currentMissingCount} already missing");
+                return false;
             }
 
             // Send an acknowledgement


### PR DESCRIPTION
This PR fixes two denial-of-service issues in the DTLS listener:

1. Half-open DTLS peers could remain in `existingPeers` indefinitely when no application-level UDP connection had been created.
2. Retransmitted cookie-verified ClientHello messages caused the server to generate a new RSA signature for every retransmission.

## Half-open peer cleanup

A peer is added to `existingPeers` after a cookie-verified ClientHello, while its entry in `allConnections` is only created after the DTLS handshake completes and an application Hello is received. The stale connection path previously queued cleanup only when `allConnections` already contained the peer's ConnectionId. As a result, a client could stop during the handshake and leave its cryptographic peer state allocated permanently.

The cleanup path now removes and disposes stale peers directly when no application connection exists. Cleanup uses both the ConnectionId and the exact PeerData instance to avoid removing a replacement session that reused the same endpoint.

The timeout covers every pre-connection state, including:

- stopping after the cookie-verified ClientHello;
- sending ClientKeyExchange and ChangeCipherSpec but omitting Finished;
- completing DTLS but never sending the application Hello.

Application data forwarding now holds a small processing lease while it creates or accesses the application-level connection. This prevents the stale timer from removing a peer in the short interval between decrypting the application Hello and registering its connection.

## ServerKeyExchange signature caching

The listener previously rebuilt the complete server flight for every accepted ClientHello retransmission. This called `EncodeServerKeyExchangeMessage` each time and performed a new RSA-SHA256 signature, allowing one cookie-verified peer to consume disproportionate CPU.

The listener now caches the encoded ServerKeyExchange payload for the current peer and handshake. Retransmissions still generate fresh DTLS record sequence numbers and rebuild the records, but copy the already signed handshake payload instead of signing it again. The cache is never shared across peers or handshake epochs.

Certificate bytes and the ServerKeyExchange signature are captured as one handshake-specific certificate generation. `SetCertificate` uses a reader/writer lock so that an in-progress handshake continues using a matching certificate and private key while newly started handshakes use the replacement certificate. This avoids producing a retransmission containing a new certificate with a signature from the old key.

The cached data contains only the public certificate, ECDHE parameters, public key, algorithms, and RSA signature. It does not contain the ECDHE private key, shared secret, or master secret. The public cache is released when the epoch transition is completed.

## Tests

Added regression coverage for:

- eviction after a cookie-verified ClientHello is left half-open;
- eviction after ClientKeyExchange and ChangeCipherSpec are accepted but Finished is omitted;
- reuse of exactly one RSA signature across ClientHello retransmissions within the same half-open handshake;
- normal DTLS connection and retransmission behavior.

Validation performed:

- `net472` and `netstandard2.0` builds pass;
- all 46 DTLS tests pass;
- the three security regression tests pass across five repeated runs (15/15);
- the first commit builds and its cleanup tests pass when checked out independently;
- the full suite passes 165/166 tests. The remaining `UdpReliableMessageAckWithDropTest` failure is an existing timing-sensitive UDP ACK test and reproduces on the unchanged baseline.
